### PR TITLE
Milestone 2: Extension skeleton with hog: protocol registration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,23 +19,25 @@ set(EXTENSION_NAME ${TARGET_NAME}_extension)
 set(LOADABLE_EXTENSION_NAME ${TARGET_NAME}_loadable_extension)
 
 project(${TARGET_NAME})
-include_directories(src/include)
+include_directories(src/include src)
 
-# Milestone 1: Basic extension that loads and prints version
+# Extension sources
 set(EXTENSION_SOURCES
     src/posthog_extension.cpp
+    # Milestone 2: Storage extension with hog: protocol registration
+    src/storage/posthog_storage.cpp
+    src/storage/posthog_transaction_manager.cpp
+    src/catalog/posthog_catalog.cpp
+    src/utils/connection_string.cpp
 )
 
-# Milestone 2+ sources (uncomment when implementing):
+# Milestone 3+ sources (uncomment when implementing):
 # list(APPEND EXTENSION_SOURCES
-#     src/storage/posthog_storage.cpp
-#     src/catalog/posthog_catalog.cpp
 #     src/catalog/posthog_schema.cpp
 #     src/catalog/posthog_table.cpp
 #     src/catalog/remote_scan.cpp
 #     src/flight/flight_client.cpp
 #     src/flight/arrow_conversion.cpp
-#     src/utils/connection_string.cpp
 # )
 
 build_static_extension(${TARGET_NAME} ${EXTENSION_SOURCES})

--- a/src/catalog/posthog_catalog.cpp
+++ b/src/catalog/posthog_catalog.cpp
@@ -1,0 +1,97 @@
+//===----------------------------------------------------------------------===//
+//                         PostHog DuckDB Extension
+//
+// catalog/posthog_catalog.cpp
+//
+//===----------------------------------------------------------------------===//
+
+#include "catalog/posthog_catalog.hpp"
+#include "duckdb/parser/parsed_data/create_schema_info.hpp"
+#include "duckdb/parser/parsed_data/drop_info.hpp"
+#include "duckdb/planner/operator/logical_create_table.hpp"
+#include "duckdb/planner/operator/logical_insert.hpp"
+#include "duckdb/planner/operator/logical_delete.hpp"
+#include "duckdb/planner/operator/logical_update.hpp"
+#include "duckdb/storage/database_size.hpp"
+
+#include <iostream>
+
+namespace duckdb {
+
+PostHogCatalog::PostHogCatalog(AttachedDatabase &db, const string &name, PostHogConnectionConfig config)
+    : Catalog(db), database_name_(name), config_(std::move(config)) {
+}
+
+PostHogCatalog::~PostHogCatalog() = default;
+
+void PostHogCatalog::Initialize(bool load_builtin) {
+    // Log successful attachment (Milestone 2 requirement)
+    // In production, this would be where we connect to the Flight server
+    std::cerr << "[PostHog] Attached to remote database: " << config_.database << std::endl;
+    std::cerr << "[PostHog] Endpoint: " << config_.endpoint << std::endl;
+    std::cerr << "[PostHog] Token: " << (config_.token.empty() ? "(none)" : "(provided)") << std::endl;
+}
+
+optional_ptr<CatalogEntry> PostHogCatalog::CreateSchema(CatalogTransaction transaction, CreateSchemaInfo &info) {
+    throw NotImplementedException("PostHog: CreateSchema not yet implemented (requires Flight connection)");
+}
+
+void PostHogCatalog::ScanSchemas(ClientContext &context, std::function<void(SchemaCatalogEntry &)> callback) {
+    // For Milestone 2, we don't have any schemas yet
+    // This will be populated when we connect to the Flight server in Milestone 3
+}
+
+optional_ptr<SchemaCatalogEntry> PostHogCatalog::LookupSchema(CatalogTransaction transaction,
+                                                              const EntryLookupInfo &schema_lookup,
+                                                              OnEntryNotFound if_not_found) {
+    // For Milestone 2, no schemas are available yet
+    if (if_not_found == OnEntryNotFound::THROW_EXCEPTION) {
+        throw CatalogException("PostHog: Schema lookup not yet implemented (requires Flight connection)");
+    }
+    return nullptr;
+}
+
+PhysicalOperator &PostHogCatalog::PlanInsert(ClientContext &context, PhysicalPlanGenerator &planner, LogicalInsert &op,
+                                             optional_ptr<PhysicalOperator> plan) {
+    throw NotImplementedException("PostHog: INSERT not yet implemented");
+}
+
+PhysicalOperator &PostHogCatalog::PlanCreateTableAs(ClientContext &context, PhysicalPlanGenerator &planner,
+                                                    LogicalCreateTable &op, PhysicalOperator &plan) {
+    throw NotImplementedException("PostHog: CREATE TABLE AS not yet implemented");
+}
+
+PhysicalOperator &PostHogCatalog::PlanDelete(ClientContext &context, PhysicalPlanGenerator &planner, LogicalDelete &op,
+                                             PhysicalOperator &plan) {
+    throw NotImplementedException("PostHog: DELETE not yet implemented");
+}
+
+PhysicalOperator &PostHogCatalog::PlanUpdate(ClientContext &context, PhysicalPlanGenerator &planner, LogicalUpdate &op,
+                                             PhysicalOperator &plan) {
+    throw NotImplementedException("PostHog: UPDATE not yet implemented");
+}
+
+DatabaseSize PostHogCatalog::GetDatabaseSize(ClientContext &context) {
+    DatabaseSize size;
+    size.free_blocks = 0;
+    size.total_blocks = 0;
+    size.used_blocks = 0;
+    size.wal_size = 0;
+    size.block_size = 0;
+    size.bytes = 0;
+    return size;
+}
+
+bool PostHogCatalog::InMemory() {
+    return false;  // This is a remote database
+}
+
+string PostHogCatalog::GetDBPath() {
+    return config_.endpoint;
+}
+
+void PostHogCatalog::DropSchema(ClientContext &context, DropInfo &info) {
+    throw NotImplementedException("PostHog: DROP SCHEMA not yet implemented");
+}
+
+} // namespace duckdb

--- a/src/catalog/posthog_catalog.hpp
+++ b/src/catalog/posthog_catalog.hpp
@@ -1,0 +1,64 @@
+//===----------------------------------------------------------------------===//
+//                         PostHog DuckDB Extension
+//
+// catalog/posthog_catalog.hpp
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/catalog/catalog.hpp"
+#include "utils/connection_string.hpp"
+
+namespace duckdb {
+
+class PostHogCatalog : public Catalog {
+public:
+    PostHogCatalog(AttachedDatabase &db, const string &name, PostHogConnectionConfig config);
+    ~PostHogCatalog() override;
+
+public:
+    void Initialize(bool load_builtin) override;
+
+    string GetCatalogType() override {
+        return "hog";
+    }
+
+    optional_ptr<CatalogEntry> CreateSchema(CatalogTransaction transaction, CreateSchemaInfo &info) override;
+
+    void ScanSchemas(ClientContext &context, std::function<void(SchemaCatalogEntry &)> callback) override;
+
+    optional_ptr<SchemaCatalogEntry> LookupSchema(CatalogTransaction transaction, const EntryLookupInfo &schema_lookup,
+                                                  OnEntryNotFound if_not_found) override;
+
+    PhysicalOperator &PlanInsert(ClientContext &context, PhysicalPlanGenerator &planner, LogicalInsert &op,
+                                 optional_ptr<PhysicalOperator> plan) override;
+    PhysicalOperator &PlanCreateTableAs(ClientContext &context, PhysicalPlanGenerator &planner, LogicalCreateTable &op,
+                                        PhysicalOperator &plan) override;
+    PhysicalOperator &PlanDelete(ClientContext &context, PhysicalPlanGenerator &planner, LogicalDelete &op,
+                                 PhysicalOperator &plan) override;
+    PhysicalOperator &PlanUpdate(ClientContext &context, PhysicalPlanGenerator &planner, LogicalUpdate &op,
+                                 PhysicalOperator &plan) override;
+
+    DatabaseSize GetDatabaseSize(ClientContext &context) override;
+
+    bool InMemory() override;
+    string GetDBPath() override;
+
+    // Accessors for configuration
+    const PostHogConnectionConfig &GetConfig() const {
+        return config_;
+    }
+    const string &GetDatabaseName() const {
+        return database_name_;
+    }
+
+private:
+    void DropSchema(ClientContext &context, DropInfo &info) override;
+
+private:
+    string database_name_;
+    PostHogConnectionConfig config_;
+};
+
+} // namespace duckdb

--- a/src/storage/posthog_storage.cpp
+++ b/src/storage/posthog_storage.cpp
@@ -1,0 +1,50 @@
+//===----------------------------------------------------------------------===//
+//                         PostHog DuckDB Extension
+//
+// storage/posthog_storage.cpp
+//
+//===----------------------------------------------------------------------===//
+
+#include "duckdb.hpp"
+
+#include "storage/posthog_storage.hpp"
+#include "storage/posthog_transaction_manager.hpp"
+#include "catalog/posthog_catalog.hpp"
+#include "utils/connection_string.hpp"
+
+namespace duckdb {
+
+static unique_ptr<Catalog> PostHogAttach(optional_ptr<StorageExtensionInfo> storage_info, ClientContext &context,
+                                         AttachedDatabase &db, const string &name, AttachInfo &info,
+                                         AttachOptions &attach_options) {
+    // Parse the connection string
+    auto config = ConnectionString::Parse(info.path);
+
+    // Validate required parameters
+    if (config.token.empty()) {
+        throw InvalidInputException(
+            "PostHog: Missing authentication token. Use: ATTACH 'hog:database?token=YOUR_TOKEN'");
+    }
+
+    // Use default endpoint if not specified
+    if (config.endpoint.empty()) {
+        config.endpoint = PostHogConnectionConfig::DEFAULT_ENDPOINT;
+    }
+
+    // For now (Milestone 2), we don't actually connect to the Flight server
+    // Just create the catalog with the configuration
+    return make_uniq<PostHogCatalog>(db, name, std::move(config));
+}
+
+static unique_ptr<TransactionManager> PostHogCreateTransactionManager(
+    optional_ptr<StorageExtensionInfo> storage_info, AttachedDatabase &db, Catalog &catalog) {
+    auto &posthog_catalog = catalog.Cast<PostHogCatalog>();
+    return make_uniq<PostHogTransactionManager>(db, posthog_catalog);
+}
+
+PostHogStorageExtension::PostHogStorageExtension() {
+    attach = PostHogAttach;
+    create_transaction_manager = PostHogCreateTransactionManager;
+}
+
+} // namespace duckdb

--- a/src/storage/posthog_storage.hpp
+++ b/src/storage/posthog_storage.hpp
@@ -1,0 +1,19 @@
+//===----------------------------------------------------------------------===//
+//                         PostHog DuckDB Extension
+//
+// storage/posthog_storage.hpp
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/storage/storage_extension.hpp"
+
+namespace duckdb {
+
+class PostHogStorageExtension : public StorageExtension {
+public:
+    PostHogStorageExtension();
+};
+
+} // namespace duckdb

--- a/src/storage/posthog_transaction.hpp
+++ b/src/storage/posthog_transaction.hpp
@@ -1,0 +1,23 @@
+//===----------------------------------------------------------------------===//
+//                         PostHog DuckDB Extension
+//
+// storage/posthog_transaction.hpp
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/transaction/transaction.hpp"
+
+namespace duckdb {
+
+class PostHogTransaction : public Transaction {
+public:
+    PostHogTransaction(TransactionManager &manager, ClientContext &context)
+        : Transaction(manager, context) {
+    }
+
+    static PostHogTransaction &Get(ClientContext &context, Catalog &catalog);
+};
+
+} // namespace duckdb

--- a/src/storage/posthog_transaction_manager.cpp
+++ b/src/storage/posthog_transaction_manager.cpp
@@ -1,0 +1,45 @@
+//===----------------------------------------------------------------------===//
+//                         PostHog DuckDB Extension
+//
+// storage/posthog_transaction_manager.cpp
+//
+//===----------------------------------------------------------------------===//
+
+#include "storage/posthog_transaction_manager.hpp"
+#include "catalog/posthog_catalog.hpp"
+
+namespace duckdb {
+
+PostHogTransactionManager::PostHogTransactionManager(AttachedDatabase &db_p, PostHogCatalog &catalog)
+    : TransactionManager(db_p), catalog_(catalog) {
+}
+
+Transaction &PostHogTransactionManager::StartTransaction(ClientContext &context) {
+    lock_guard<mutex> guard(transaction_lock_);
+
+    auto transaction = make_uniq<PostHogTransaction>(*this, context);
+    auto &result = *transaction;
+    transactions_[result] = std::move(transaction);
+    return result;
+}
+
+ErrorData PostHogTransactionManager::CommitTransaction(ClientContext &context, Transaction &transaction) {
+    lock_guard<mutex> guard(transaction_lock_);
+
+    // For read-only operations, commit is a no-op
+    transactions_.erase(transaction);
+    return ErrorData();
+}
+
+void PostHogTransactionManager::RollbackTransaction(Transaction &transaction) {
+    lock_guard<mutex> guard(transaction_lock_);
+
+    // For read-only operations, rollback is a no-op
+    transactions_.erase(transaction);
+}
+
+void PostHogTransactionManager::Checkpoint(ClientContext &context, bool force) {
+    // Remote database - no local checkpoint needed
+}
+
+} // namespace duckdb

--- a/src/storage/posthog_transaction_manager.hpp
+++ b/src/storage/posthog_transaction_manager.hpp
@@ -1,0 +1,33 @@
+//===----------------------------------------------------------------------===//
+//                         PostHog DuckDB Extension
+//
+// storage/posthog_transaction_manager.hpp
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/transaction/transaction_manager.hpp"
+#include "duckdb/common/reference_map.hpp"
+#include "storage/posthog_transaction.hpp"
+
+namespace duckdb {
+
+class PostHogCatalog;
+
+class PostHogTransactionManager : public TransactionManager {
+public:
+    PostHogTransactionManager(AttachedDatabase &db_p, PostHogCatalog &catalog);
+
+    Transaction &StartTransaction(ClientContext &context) override;
+    ErrorData CommitTransaction(ClientContext &context, Transaction &transaction) override;
+    void RollbackTransaction(Transaction &transaction) override;
+    void Checkpoint(ClientContext &context, bool force = false) override;
+
+private:
+    PostHogCatalog &catalog_;
+    mutex transaction_lock_;
+    reference_map_t<Transaction, unique_ptr<PostHogTransaction>> transactions_;
+};
+
+} // namespace duckdb

--- a/src/utils/connection_string.cpp
+++ b/src/utils/connection_string.cpp
@@ -1,0 +1,86 @@
+//===----------------------------------------------------------------------===//
+//                         PostHog DuckDB Extension
+//
+// utils/connection_string.cpp
+//
+//===----------------------------------------------------------------------===//
+
+#include "utils/connection_string.hpp"
+#include <stdexcept>
+#include <sstream>
+
+namespace duckdb {
+
+std::string ConnectionString::UrlDecode(const std::string &str) {
+    std::string result;
+    result.reserve(str.size());
+
+    for (size_t i = 0; i < str.size(); i++) {
+        if (str[i] == '%' && i + 2 < str.size()) {
+            // Parse hex digits
+            char hex[3] = {str[i + 1], str[i + 2], '\0'};
+            char *end;
+            long value = strtol(hex, &end, 16);
+            if (end == hex + 2) {
+                result += static_cast<char>(value);
+                i += 2;
+                continue;
+            }
+        } else if (str[i] == '+') {
+            result += ' ';
+            continue;
+        }
+        result += str[i];
+    }
+
+    return result;
+}
+
+PostHogConnectionConfig ConnectionString::Parse(const std::string &connection_string) {
+    PostHogConnectionConfig config;
+
+    std::string uri = connection_string;
+
+    // Split database name and query parameters at '?'
+    auto query_pos = uri.find('?');
+    if (query_pos != std::string::npos) {
+        config.database = uri.substr(0, query_pos);
+        std::string query = uri.substr(query_pos + 1);
+
+        // Parse query parameters (key=value&key=value...)
+        std::string::size_type pos = 0;
+        while (pos < query.size()) {
+            // Find the next '&' or end of string
+            auto amp_pos = query.find('&', pos);
+            std::string param;
+            if (amp_pos != std::string::npos) {
+                param = query.substr(pos, amp_pos - pos);
+                pos = amp_pos + 1;
+            } else {
+                param = query.substr(pos);
+                pos = query.size();
+            }
+
+            // Split at '='
+            auto eq_pos = param.find('=');
+            if (eq_pos != std::string::npos) {
+                std::string key = param.substr(0, eq_pos);
+                std::string value = UrlDecode(param.substr(eq_pos + 1));
+
+                if (key == "token") {
+                    config.token = value;
+                } else if (key == "endpoint") {
+                    config.endpoint = value;
+                } else {
+                    config.options[key] = value;
+                }
+            }
+        }
+    } else {
+        config.database = uri;
+    }
+
+    return config;
+}
+
+} // namespace duckdb

--- a/src/utils/connection_string.hpp
+++ b/src/utils/connection_string.hpp
@@ -1,0 +1,36 @@
+//===----------------------------------------------------------------------===//
+//                         PostHog DuckDB Extension
+//
+// utils/connection_string.hpp
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <string>
+#include <unordered_map>
+
+namespace duckdb {
+
+struct PostHogConnectionConfig {
+    std::string database;
+    std::string token;
+    std::string endpoint;
+    std::unordered_map<std::string, std::string> options;
+
+    // Default Flight SQL endpoint
+    static constexpr const char *DEFAULT_ENDPOINT = "grpc://localhost:8815";
+};
+
+class ConnectionString {
+public:
+    // Parse connection string format: "database_name?token=abc123&endpoint=grpc://host:port"
+    // The "hog:" prefix is stripped by DuckDB before this is called
+    static PostHogConnectionConfig Parse(const std::string &connection_string);
+
+private:
+    // URL decode a string (handles %XX encoding)
+    static std::string UrlDecode(const std::string &str);
+};
+
+} // namespace duckdb


### PR DESCRIPTION
Implements the core storage extension infrastructure:
- PostHogStorageExtension registers "hog:" protocol prefix
- Connection string parser for database?token=xxx&endpoint=yyy format
- PostHogCatalog stub with read-only transaction manager
- Logs successful attachment with endpoint and token status

Usage: ATTACH 'hog:database?token=xxx&endpoint=grpc://host:port'