### PR TITLE
Milestone 4: Virtual catalog with proxy table entries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,10 @@ set(EXTENSION_SOURCES
     # Milestone 3: Arrow Flight SQL client integration
     src/flight/flight_client.cpp
     src/flight/arrow_conversion.cpp
+    # Milestone 4: Virtual catalog with proxy table entries
+    src/catalog/posthog_schema_entry.cpp
+    src/catalog/posthog_table_entry.cpp
+    src/catalog/remote_scan.cpp
 )
 
 build_static_extension(${TARGET_NAME} ${EXTENSION_SOURCES})

--- a/src/catalog/posthog_catalog.cpp
+++ b/src/catalog/posthog_catalog.cpp
@@ -6,6 +6,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "catalog/posthog_catalog.hpp"
+#include "catalog/posthog_schema_entry.hpp"
 #include "duckdb/parser/parsed_data/create_schema_info.hpp"
 #include "duckdb/parser/parsed_data/drop_info.hpp"
 #include "duckdb/planner/operator/logical_create_table.hpp"
@@ -45,8 +46,95 @@ void PostHogCatalog::Initialize(bool load_builtin) {
 }
 
 optional_ptr<CatalogEntry> PostHogCatalog::CreateSchema(CatalogTransaction transaction, CreateSchemaInfo &info) {
-    throw NotImplementedException("PostHog: CreateSchema not yet implemented (requires Flight connection)");
+    throw NotImplementedException("PostHog: CreateSchema not supported on remote database");
 }
+
+//===----------------------------------------------------------------------===//
+// Schema Loading (Lazy)
+//===----------------------------------------------------------------------===//
+
+void PostHogCatalog::LoadSchemasIfNeeded() {
+    std::lock_guard<std::mutex> lock(schemas_mutex_);
+
+    // Check if cache is still valid
+    if (schemas_loaded_) {
+        auto now = std::chrono::steady_clock::now();
+        auto elapsed = std::chrono::duration_cast<std::chrono::seconds>(now - schemas_loaded_at_).count();
+        if (elapsed < CACHE_TTL_SECONDS) {
+            return; // Cache is still valid
+        }
+        // Cache expired, need to refresh
+        std::cerr << "[PostHog] Schema cache expired, refreshing..." << std::endl;
+    }
+
+    if (!IsConnected()) {
+        std::cerr << "[PostHog] Cannot load schemas: not connected" << std::endl;
+        return;
+    }
+
+    try {
+        std::cerr << "[PostHog] Loading schemas from remote server..." << std::endl;
+        auto schema_names = flight_client_->ListSchemas();
+
+        // Create schema entries (don't clear existing ones to preserve loaded tables)
+        for (const auto &schema_name : schema_names) {
+            if (schema_cache_.find(schema_name) == schema_cache_.end()) {
+                CreateSchemaEntry(schema_name);
+            }
+        }
+
+        schemas_loaded_ = true;
+        schemas_loaded_at_ = std::chrono::steady_clock::now();
+        std::cerr << "[PostHog] Loaded " << schema_names.size() << " schemas" << std::endl;
+
+    } catch (const std::exception &e) {
+        std::cerr << "[PostHog] Failed to load schemas: " << e.what() << std::endl;
+    }
+}
+
+void PostHogCatalog::CreateSchemaEntry(const string &schema_name) {
+    auto schema_info = make_uniq<CreateSchemaInfo>();
+    schema_info->schema = schema_name;
+    schema_info->on_conflict = OnCreateConflict::IGNORE_ON_CONFLICT;
+
+    auto schema_entry = make_uniq<PostHogSchemaEntry>(*this, *schema_info, *this);
+    schema_cache_[schema_name] = std::move(schema_entry);
+}
+
+optional_ptr<PostHogSchemaEntry> PostHogCatalog::GetOrCreateSchema(const string &schema_name) {
+    std::lock_guard<std::mutex> lock(schemas_mutex_);
+
+    auto it = schema_cache_.find(schema_name);
+    if (it != schema_cache_.end()) {
+        return it->second.get();
+    }
+
+    // Schema not in cache - try to create it if we're connected
+    if (!IsConnected()) {
+        return nullptr;
+    }
+
+    // Create the schema entry on-demand
+    CreateSchemaEntry(schema_name);
+    it = schema_cache_.find(schema_name);
+    if (it != schema_cache_.end()) {
+        return it->second.get();
+    }
+    return nullptr;
+}
+
+void PostHogCatalog::RefreshSchemas() {
+    std::lock_guard<std::mutex> lock(schemas_mutex_);
+    schemas_loaded_ = false;
+    // Also refresh tables in each schema
+    for (auto &entry : schema_cache_) {
+        entry.second->RefreshTables();
+    }
+}
+
+//===----------------------------------------------------------------------===//
+// Schema Scanning and Lookup
+//===----------------------------------------------------------------------===//
 
 void PostHogCatalog::ScanSchemas(ClientContext &context, std::function<void(SchemaCatalogEntry &)> callback) {
     // If not connected, no schemas are available
@@ -54,9 +142,12 @@ void PostHogCatalog::ScanSchemas(ClientContext &context, std::function<void(Sche
         return;
     }
 
-    // TODO (Milestone 4): Implement schema scanning using flight_client_->ListSchemas()
-    // This requires creating SchemaCatalogEntry objects for each remote schema
-    // For now, schemas will be populated when Milestone 4 (Virtual Catalog) is implemented
+    LoadSchemasIfNeeded();
+
+    std::lock_guard<std::mutex> lock(schemas_mutex_);
+    for (auto &entry : schema_cache_) {
+        callback(*entry.second);
+    }
 }
 
 optional_ptr<SchemaCatalogEntry> PostHogCatalog::LookupSchema(CatalogTransaction transaction,
@@ -65,18 +156,26 @@ optional_ptr<SchemaCatalogEntry> PostHogCatalog::LookupSchema(CatalogTransaction
     // Check connection status
     if (!IsConnected()) {
         if (if_not_found == OnEntryNotFound::THROW_EXCEPTION) {
-            throw CatalogException("PostHog: Not connected to remote server. Schema lookup failed.");
+            throw CatalogException("PostHog: Not connected to remote server. Schema lookup failed for '%s'.",
+                                   schema_lookup.GetEntryName());
         }
         return nullptr;
     }
 
-    // TODO (Milestone 4): Implement schema lookup using cached schema entries
-    // This requires creating SchemaCatalogEntry objects for each remote schema
-    // For now, return nullptr as schemas will be populated in Milestone 4
-    if (if_not_found == OnEntryNotFound::THROW_EXCEPTION) {
-        throw CatalogException("PostHog: Schema lookup not yet fully implemented (Milestone 4)");
+    // Load schemas if needed
+    LoadSchemasIfNeeded();
+
+    // Look up the schema
+    auto schema = GetOrCreateSchema(schema_lookup.GetEntryName());
+    if (!schema) {
+        if (if_not_found == OnEntryNotFound::THROW_EXCEPTION) {
+            throw CatalogException("PostHog: Schema '%s' not found in remote database.", schema_lookup.GetEntryName());
+        }
+        return nullptr;
     }
-    return nullptr;
+
+    // Return as SchemaCatalogEntry pointer (PostHogSchemaEntry inherits from SchemaCatalogEntry)
+    return schema.get();
 }
 
 PhysicalOperator &PostHogCatalog::PlanInsert(ClientContext &context, PhysicalPlanGenerator &planner, LogicalInsert &op,

--- a/src/catalog/posthog_schema_entry.cpp
+++ b/src/catalog/posthog_schema_entry.cpp
@@ -1,0 +1,251 @@
+//===----------------------------------------------------------------------===//
+//                         PostHog DuckDB Extension
+//
+// catalog/posthog_schema_entry.cpp
+//
+// Virtual schema entry implementation for remote PostHog schemas
+//===----------------------------------------------------------------------===//
+
+#include "catalog/posthog_schema_entry.hpp"
+#include "catalog/posthog_catalog.hpp"
+#include "catalog/posthog_table_entry.hpp"
+#include "flight/arrow_conversion.hpp"
+
+#include "duckdb/catalog/catalog.hpp"
+#include "duckdb/catalog/entry_lookup_info.hpp"
+#include "duckdb/common/exception.hpp"
+#include "duckdb/parser/parsed_data/create_table_info.hpp"
+
+#include <iostream>
+
+namespace duckdb {
+
+PostHogSchemaEntry::PostHogSchemaEntry(Catalog &catalog, CreateSchemaInfo &info, PostHogCatalog &posthog_catalog)
+    : SchemaCatalogEntry(catalog, info), posthog_catalog_(posthog_catalog) {
+}
+
+PostHogSchemaEntry::~PostHogSchemaEntry() = default;
+
+//===----------------------------------------------------------------------===//
+// Create Operations (Not Supported for Remote)
+//===----------------------------------------------------------------------===//
+
+optional_ptr<CatalogEntry> PostHogSchemaEntry::CreateTable(CatalogTransaction transaction, BoundCreateTableInfo &info) {
+    throw NotImplementedException("PostHog: CREATE TABLE not supported on remote database");
+}
+
+optional_ptr<CatalogEntry> PostHogSchemaEntry::CreateFunction(CatalogTransaction transaction, CreateFunctionInfo &info) {
+    throw NotImplementedException("PostHog: CREATE FUNCTION not supported on remote database");
+}
+
+optional_ptr<CatalogEntry> PostHogSchemaEntry::CreateIndex(CatalogTransaction transaction, CreateIndexInfo &info,
+                                                           TableCatalogEntry &table) {
+    throw NotImplementedException("PostHog: CREATE INDEX not supported on remote database");
+}
+
+optional_ptr<CatalogEntry> PostHogSchemaEntry::CreateView(CatalogTransaction transaction, CreateViewInfo &info) {
+    throw NotImplementedException("PostHog: CREATE VIEW not supported on remote database");
+}
+
+optional_ptr<CatalogEntry> PostHogSchemaEntry::CreateSequence(CatalogTransaction transaction, CreateSequenceInfo &info) {
+    throw NotImplementedException("PostHog: CREATE SEQUENCE not supported on remote database");
+}
+
+optional_ptr<CatalogEntry> PostHogSchemaEntry::CreateTableFunction(CatalogTransaction transaction,
+                                                                   CreateTableFunctionInfo &info) {
+    throw NotImplementedException("PostHog: CREATE TABLE FUNCTION not supported on remote database");
+}
+
+optional_ptr<CatalogEntry> PostHogSchemaEntry::CreateCopyFunction(CatalogTransaction transaction,
+                                                                  CreateCopyFunctionInfo &info) {
+    throw NotImplementedException("PostHog: CREATE COPY FUNCTION not supported on remote database");
+}
+
+optional_ptr<CatalogEntry> PostHogSchemaEntry::CreatePragmaFunction(CatalogTransaction transaction,
+                                                                    CreatePragmaFunctionInfo &info) {
+    throw NotImplementedException("PostHog: CREATE PRAGMA FUNCTION not supported on remote database");
+}
+
+optional_ptr<CatalogEntry> PostHogSchemaEntry::CreateCollation(CatalogTransaction transaction, CreateCollationInfo &info) {
+    throw NotImplementedException("PostHog: CREATE COLLATION not supported on remote database");
+}
+
+optional_ptr<CatalogEntry> PostHogSchemaEntry::CreateType(CatalogTransaction transaction, CreateTypeInfo &info) {
+    throw NotImplementedException("PostHog: CREATE TYPE not supported on remote database");
+}
+
+//===----------------------------------------------------------------------===//
+// Alter/Drop Operations
+//===----------------------------------------------------------------------===//
+
+void PostHogSchemaEntry::Alter(CatalogTransaction transaction, AlterInfo &info) {
+    throw NotImplementedException("PostHog: ALTER not supported on remote database");
+}
+
+void PostHogSchemaEntry::DropEntry(ClientContext &context, DropInfo &info) {
+    throw NotImplementedException("PostHog: DROP not supported on remote database");
+}
+
+//===----------------------------------------------------------------------===//
+// Table Loading (Lazy)
+//===----------------------------------------------------------------------===//
+
+void PostHogSchemaEntry::LoadTablesIfNeeded() {
+    // Note: This method is called while holding tables_mutex_ from the caller
+    // or should be called with the lock already held
+
+    // Check if cache is still valid
+    if (tables_loaded_) {
+        auto now = std::chrono::steady_clock::now();
+        auto elapsed = std::chrono::duration_cast<std::chrono::seconds>(now - tables_loaded_at_).count();
+        if (elapsed < CACHE_TTL_SECONDS) {
+            return; // Cache is still valid
+        }
+        // Cache expired, need to refresh
+        std::cerr << "[PostHog] Table cache expired for schema " << name << ", refreshing..." << std::endl;
+    }
+
+    if (!posthog_catalog_.IsConnected()) {
+        std::cerr << "[PostHog] Cannot load tables: not connected" << std::endl;
+        return;
+    }
+
+    try {
+        std::cerr << "[PostHog] Loading tables for schema: " << name << std::endl;
+        auto &client = posthog_catalog_.GetFlightClient();
+        auto table_names = client.ListTables(name);
+
+        // Create entries for tables not already in cache
+        for (const auto &table_name : table_names) {
+            if (table_cache_.find(table_name) == table_cache_.end()) {
+                CreateTableEntry(table_name);
+            }
+        }
+
+        tables_loaded_ = true;
+        tables_loaded_at_ = std::chrono::steady_clock::now();
+        std::cerr << "[PostHog] Loaded " << table_names.size() << " tables for schema " << name << std::endl;
+
+    } catch (const std::exception &e) {
+        std::cerr << "[PostHog] Failed to load tables for schema " << name << ": " << e.what() << std::endl;
+    }
+}
+
+void PostHogSchemaEntry::CreateTableEntry(const string &table_name) {
+    // Note: Called with tables_mutex_ already held
+
+    if (!posthog_catalog_.IsConnected()) {
+        return;
+    }
+
+    // Skip if already exists
+    if (table_cache_.find(table_name) != table_cache_.end()) {
+        return;
+    }
+
+    try {
+        auto &client = posthog_catalog_.GetFlightClient();
+        auto arrow_schema = client.GetTableSchema(name, table_name);
+
+        // Convert Arrow schema to DuckDB column definitions
+        vector<string> column_names;
+        vector<LogicalType> column_types;
+        ArrowConversion::ArrowSchemaToDuckDB(arrow_schema, column_names, column_types);
+
+        // Create the table info
+        auto table_info = make_uniq<CreateTableInfo>();
+        table_info->table = table_name;
+        table_info->schema = name;
+        table_info->on_conflict = OnCreateConflict::IGNORE_ON_CONFLICT;
+
+        for (size_t i = 0; i < column_names.size(); i++) {
+            table_info->columns.AddColumn(ColumnDefinition(column_names[i], column_types[i]));
+        }
+
+        // Create the table entry and add to cache
+        auto table_entry = make_uniq<PostHogTableEntry>(catalog, *this, *table_info, posthog_catalog_);
+        table_cache_[table_name] = std::move(table_entry);
+
+    } catch (const std::exception &e) {
+        std::cerr << "[PostHog] Failed to create table entry for " << name << "." << table_name << ": " << e.what()
+                  << std::endl;
+    }
+}
+
+optional_ptr<PostHogTableEntry> PostHogSchemaEntry::GetOrCreateTable(const string &table_name) {
+    // Note: Called with tables_mutex_ already held
+
+    auto it = table_cache_.find(table_name);
+    if (it != table_cache_.end()) {
+        return it->second.get();
+    }
+
+    // Table not in cache - try to create it if we're connected
+    if (!posthog_catalog_.IsConnected()) {
+        return nullptr;
+    }
+
+    // Create the table entry on-demand
+    CreateTableEntry(table_name);
+    it = table_cache_.find(table_name);
+    if (it != table_cache_.end()) {
+        return it->second.get();
+    }
+    return nullptr;
+}
+
+void PostHogSchemaEntry::RefreshTables() {
+    std::lock_guard<std::mutex> lock(tables_mutex_);
+    tables_loaded_ = false;
+}
+
+//===----------------------------------------------------------------------===//
+// Scan and Lookup
+//===----------------------------------------------------------------------===//
+
+void PostHogSchemaEntry::Scan(ClientContext &context, CatalogType type,
+                              const std::function<void(CatalogEntry &)> &callback) {
+    if (type != CatalogType::TABLE_ENTRY) {
+        // We only have tables in remote schemas
+        return;
+    }
+
+    std::lock_guard<std::mutex> lock(tables_mutex_);
+    LoadTablesIfNeeded();
+
+    for (auto &entry : table_cache_) {
+        callback(*entry.second);
+    }
+}
+
+void PostHogSchemaEntry::Scan(CatalogType type, const std::function<void(CatalogEntry &)> &callback) {
+    if (type != CatalogType::TABLE_ENTRY) {
+        return;
+    }
+
+    std::lock_guard<std::mutex> lock(tables_mutex_);
+    LoadTablesIfNeeded();
+
+    for (auto &entry : table_cache_) {
+        callback(*entry.second);
+    }
+}
+
+optional_ptr<CatalogEntry> PostHogSchemaEntry::LookupEntry(CatalogTransaction transaction,
+                                                          const EntryLookupInfo &lookup_info) {
+    if (lookup_info.GetCatalogType() != CatalogType::TABLE_ENTRY) {
+        return nullptr;
+    }
+
+    std::lock_guard<std::mutex> lock(tables_mutex_);
+    LoadTablesIfNeeded();
+
+    // Try to get from cache, or create on-demand
+    auto table = GetOrCreateTable(lookup_info.GetEntryName());
+    if (table) {
+        return table.get();
+    }
+    return nullptr;
+}
+
+} // namespace duckdb

--- a/src/catalog/posthog_schema_entry.hpp
+++ b/src/catalog/posthog_schema_entry.hpp
@@ -1,0 +1,95 @@
+//===----------------------------------------------------------------------===//
+//                         PostHog DuckDB Extension
+//
+// catalog/posthog_schema_entry.hpp
+//
+// Virtual schema entry for remote PostHog schemas
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/catalog/catalog_entry/schema_catalog_entry.hpp"
+
+#include <unordered_map>
+#include <mutex>
+#include <chrono>
+
+namespace duckdb {
+
+class PostHogCatalog;
+class PostHogTableEntry;
+
+class PostHogSchemaEntry : public SchemaCatalogEntry {
+public:
+    PostHogSchemaEntry(Catalog &catalog, CreateSchemaInfo &info, PostHogCatalog &posthog_catalog);
+    ~PostHogSchemaEntry() override;
+
+public:
+    //===--------------------------------------------------------------------===//
+    // Catalog Entry Interface
+    //===--------------------------------------------------------------------===//
+
+    optional_ptr<CatalogEntry> CreateTable(CatalogTransaction transaction, BoundCreateTableInfo &info) override;
+    optional_ptr<CatalogEntry> CreateFunction(CatalogTransaction transaction, CreateFunctionInfo &info) override;
+    optional_ptr<CatalogEntry> CreateIndex(CatalogTransaction transaction, CreateIndexInfo &info,
+                                           TableCatalogEntry &table) override;
+    optional_ptr<CatalogEntry> CreateView(CatalogTransaction transaction, CreateViewInfo &info) override;
+    optional_ptr<CatalogEntry> CreateSequence(CatalogTransaction transaction, CreateSequenceInfo &info) override;
+    optional_ptr<CatalogEntry> CreateTableFunction(CatalogTransaction transaction,
+                                                   CreateTableFunctionInfo &info) override;
+    optional_ptr<CatalogEntry> CreateCopyFunction(CatalogTransaction transaction,
+                                                  CreateCopyFunctionInfo &info) override;
+    optional_ptr<CatalogEntry> CreatePragmaFunction(CatalogTransaction transaction,
+                                                    CreatePragmaFunctionInfo &info) override;
+    optional_ptr<CatalogEntry> CreateCollation(CatalogTransaction transaction, CreateCollationInfo &info) override;
+    optional_ptr<CatalogEntry> CreateType(CatalogTransaction transaction, CreateTypeInfo &info) override;
+
+    void Alter(CatalogTransaction transaction, AlterInfo &info) override;
+    void Scan(ClientContext &context, CatalogType type,
+              const std::function<void(CatalogEntry &)> &callback) override;
+    void Scan(CatalogType type, const std::function<void(CatalogEntry &)> &callback) override;
+
+    void DropEntry(ClientContext &context, DropInfo &info) override;
+
+    optional_ptr<CatalogEntry> LookupEntry(CatalogTransaction transaction, const EntryLookupInfo &lookup_info) override;
+
+    //===--------------------------------------------------------------------===//
+    // PostHog-specific methods
+    //===--------------------------------------------------------------------===//
+
+    // Get the parent PostHog catalog
+    PostHogCatalog &GetPostHogCatalog() {
+        return posthog_catalog_;
+    }
+
+    // Force refresh of table cache
+    void RefreshTables();
+
+    // Check if tables have been loaded
+    bool TablesLoaded() const {
+        return tables_loaded_;
+    }
+
+private:
+    // Load tables from remote server (lazy loading)
+    void LoadTablesIfNeeded();
+
+    // Create a table entry for a remote table
+    void CreateTableEntry(const string &table_name);
+
+    // Get or create a table entry
+    optional_ptr<PostHogTableEntry> GetOrCreateTable(const string &table_name);
+
+    PostHogCatalog &posthog_catalog_;
+
+    // Table cache (using simple map instead of CatalogSet for simplicity)
+    mutable std::mutex tables_mutex_;
+    bool tables_loaded_ = false;
+    std::chrono::steady_clock::time_point tables_loaded_at_;
+    std::unordered_map<string, unique_ptr<PostHogTableEntry>> table_cache_;
+
+    // Cache TTL (5 minutes by default)
+    static constexpr int64_t CACHE_TTL_SECONDS = 300;
+};
+
+} // namespace duckdb

--- a/src/catalog/posthog_table_entry.cpp
+++ b/src/catalog/posthog_table_entry.cpp
@@ -1,0 +1,62 @@
+//===----------------------------------------------------------------------===//
+//                         PostHog DuckDB Extension
+//
+// catalog/posthog_table_entry.cpp
+//
+// Virtual table entry implementation that proxies to a remote PostHog table
+//===----------------------------------------------------------------------===//
+
+#include "catalog/posthog_table_entry.hpp"
+#include "catalog/posthog_catalog.hpp"
+#include "catalog/posthog_schema_entry.hpp"
+#include "catalog/remote_scan.hpp"
+#include "flight/arrow_conversion.hpp"
+
+#include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
+#include "duckdb/common/exception.hpp"
+#include "duckdb/parser/constraints/not_null_constraint.hpp"
+
+#include <iostream>
+
+namespace duckdb {
+
+PostHogTableEntry::PostHogTableEntry(Catalog &catalog, SchemaCatalogEntry &schema, CreateTableInfo &info,
+                                     PostHogCatalog &posthog_catalog)
+    : TableCatalogEntry(catalog, schema, info), posthog_catalog_(posthog_catalog), schema_name_(schema.name) {
+}
+
+PostHogTableEntry::~PostHogTableEntry() = default;
+
+unique_ptr<BaseStatistics> PostHogTableEntry::GetStatistics(ClientContext &context, column_t column_id) {
+    // No statistics available for remote tables
+    return nullptr;
+}
+
+TableFunction PostHogTableEntry::GetScanFunction(ClientContext &context, unique_ptr<FunctionData> &bind_data) {
+    // Create bind data for the remote scan
+    vector<string> column_names;
+    vector<LogicalType> column_types;
+
+    for (auto &col : columns.Logical()) {
+        column_names.push_back(col.Name());
+        column_types.push_back(col.Type());
+    }
+
+    bind_data = PostHogRemoteScan::CreateBindData(posthog_catalog_, schema_name_, name, column_names, column_types);
+
+    return PostHogRemoteScan::GetFunction();
+}
+
+TableStorageInfo PostHogTableEntry::GetStorageInfo(ClientContext &context) {
+    TableStorageInfo info;
+    // Remote tables - we don't have local storage info
+    info.cardinality = 0; // Unknown
+    return info;
+}
+
+void PostHogTableEntry::BindUpdateConstraints(Binder &binder, LogicalGet &get, LogicalProjection &proj,
+                                               LogicalUpdate &update, ClientContext &context) {
+    throw NotImplementedException("PostHog: UPDATE operations are not supported on remote tables");
+}
+
+} // namespace duckdb

--- a/src/catalog/posthog_table_entry.hpp
+++ b/src/catalog/posthog_table_entry.hpp
@@ -1,0 +1,58 @@
+//===----------------------------------------------------------------------===//
+//                         PostHog DuckDB Extension
+//
+// catalog/posthog_table_entry.hpp
+//
+// Virtual table entry that proxies to a remote PostHog table
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
+#include "duckdb/storage/data_table.hpp"
+
+namespace duckdb {
+
+class PostHogCatalog;
+class PostHogSchemaEntry;
+
+class PostHogTableEntry : public TableCatalogEntry {
+public:
+    PostHogTableEntry(Catalog &catalog, SchemaCatalogEntry &schema, CreateTableInfo &info,
+                      PostHogCatalog &posthog_catalog);
+    ~PostHogTableEntry() override;
+
+public:
+    //===--------------------------------------------------------------------===//
+    // TableCatalogEntry Interface
+    //===--------------------------------------------------------------------===//
+
+    unique_ptr<BaseStatistics> GetStatistics(ClientContext &context, column_t column_id) override;
+
+    TableFunction GetScanFunction(ClientContext &context, unique_ptr<FunctionData> &bind_data) override;
+
+    TableStorageInfo GetStorageInfo(ClientContext &context) override;
+
+    void BindUpdateConstraints(Binder &binder, LogicalGet &get, LogicalProjection &proj, LogicalUpdate &update,
+                               ClientContext &context) override;
+
+    //===--------------------------------------------------------------------===//
+    // PostHog-specific methods
+    //===--------------------------------------------------------------------===//
+
+    // Get the schema name for this table
+    const string &GetSchemaName() const {
+        return schema_name_;
+    }
+
+    // Get the parent PostHog catalog
+    PostHogCatalog &GetPostHogCatalog() {
+        return posthog_catalog_;
+    }
+
+private:
+    PostHogCatalog &posthog_catalog_;
+    string schema_name_;
+};
+
+} // namespace duckdb

--- a/src/catalog/remote_scan.cpp
+++ b/src/catalog/remote_scan.cpp
@@ -1,0 +1,167 @@
+//===----------------------------------------------------------------------===//
+//                         PostHog DuckDB Extension
+//
+// catalog/remote_scan.cpp
+//
+// Table function implementation for executing remote queries via Flight SQL
+//===----------------------------------------------------------------------===//
+
+#include "catalog/remote_scan.hpp"
+#include "catalog/posthog_catalog.hpp"
+#include "flight/arrow_conversion.hpp"
+
+#include "duckdb/common/exception.hpp"
+#include "duckdb/function/table_function.hpp"
+
+#include <iostream>
+
+namespace duckdb {
+
+//===----------------------------------------------------------------------===//
+// Bind Data
+//===----------------------------------------------------------------------===//
+
+PostHogRemoteScanBindData::PostHogRemoteScanBindData(PostHogCatalog &catalog_p, const string &schema_name_p,
+                                                     const string &table_name_p)
+    : catalog(catalog_p), schema_name(schema_name_p), table_name(table_name_p) {
+}
+
+//===----------------------------------------------------------------------===//
+// Global State
+//===----------------------------------------------------------------------===//
+
+PostHogRemoteScanGlobalState::PostHogRemoteScanGlobalState() : current_row(0), executed(false) {
+}
+
+//===----------------------------------------------------------------------===//
+// Bind Function
+//===----------------------------------------------------------------------===//
+
+unique_ptr<FunctionData> PostHogRemoteScan::Bind(ClientContext &context, TableFunctionBindInput &input,
+                                                 vector<LogicalType> &return_types, vector<string> &names) {
+    // This bind function is used for direct table function calls
+    // For table scans, we use CreateBindData instead
+    throw NotImplementedException("PostHog remote_scan should not be called directly");
+}
+
+unique_ptr<FunctionData> PostHogRemoteScan::CreateBindData(PostHogCatalog &catalog, const string &schema_name,
+                                                           const string &table_name,
+                                                           const vector<string> &column_names,
+                                                           const vector<LogicalType> &column_types) {
+    auto bind_data = make_uniq<PostHogRemoteScanBindData>(catalog, schema_name, table_name);
+
+    bind_data->column_names = column_names;
+    bind_data->column_types = column_types;
+
+    // Build the SELECT query
+    // TODO: Support column projection pushdown
+    string columns_str;
+    if (column_names.empty()) {
+        columns_str = "*";
+    } else {
+        for (size_t i = 0; i < column_names.size(); i++) {
+            if (i > 0) {
+                columns_str += ", ";
+            }
+            // Quote column names to handle special characters
+            columns_str += "\"" + column_names[i] + "\"";
+        }
+    }
+
+    // Build the full query
+    // Quote schema and table names
+    bind_data->query =
+        "SELECT " + columns_str + " FROM \"" + schema_name + "\".\"" + table_name + "\"";
+
+    return bind_data;
+}
+
+//===----------------------------------------------------------------------===//
+// Init Functions
+//===----------------------------------------------------------------------===//
+
+unique_ptr<GlobalTableFunctionState> PostHogRemoteScan::InitGlobal(ClientContext &context,
+                                                                    TableFunctionInitInput &input) {
+    return make_uniq<PostHogRemoteScanGlobalState>();
+}
+
+unique_ptr<LocalTableFunctionState> PostHogRemoteScan::InitLocal(ExecutionContext &context,
+                                                                  TableFunctionInitInput &input,
+                                                                  GlobalTableFunctionState *global_state) {
+    return make_uniq<PostHogRemoteScanLocalState>();
+}
+
+//===----------------------------------------------------------------------===//
+// Execute Function
+//===----------------------------------------------------------------------===//
+
+void PostHogRemoteScan::Execute(ClientContext &context, TableFunctionInput &data, DataChunk &output) {
+    auto &bind_data = data.bind_data->Cast<PostHogRemoteScanBindData>();
+    auto &global_state = data.global_state->Cast<PostHogRemoteScanGlobalState>();
+
+    // Execute the remote query if we haven't already
+    if (!global_state.executed) {
+        if (!bind_data.catalog.IsConnected()) {
+            throw ConnectionException("PostHog: Not connected to remote server");
+        }
+
+        try {
+            std::cerr << "[PostHog] Executing remote query: " << bind_data.query << std::endl;
+            auto &client = bind_data.catalog.GetFlightClient();
+            global_state.result_table = client.ExecuteQuery(bind_data.query);
+            global_state.executed = true;
+            std::cerr << "[PostHog] Query returned " << global_state.result_table->num_rows() << " rows" << std::endl;
+        } catch (const std::exception &e) {
+            throw IOException("PostHog: Failed to execute remote query: " + string(e.what()));
+        }
+    }
+
+    // Check if we have more data to return
+    if (!global_state.result_table || global_state.current_row >= static_cast<idx_t>(global_state.result_table->num_rows())) {
+        output.SetCardinality(0);
+        return;
+    }
+
+    // Calculate how many rows to copy
+    idx_t remaining = static_cast<idx_t>(global_state.result_table->num_rows()) - global_state.current_row;
+    idx_t rows_to_copy = MinValue<idx_t>(STANDARD_VECTOR_SIZE, remaining);
+
+    // Convert Arrow data to DuckDB DataChunk
+    ArrowConversion::ArrowTableToDataChunk(global_state.result_table, output, global_state.current_row, rows_to_copy);
+
+    global_state.current_row += rows_to_copy;
+    output.SetCardinality(rows_to_copy);
+}
+
+//===----------------------------------------------------------------------===//
+// Progress Function
+//===----------------------------------------------------------------------===//
+
+double PostHogRemoteScan::Progress(ClientContext &context, const FunctionData *bind_data,
+                                    const GlobalTableFunctionState *global_state) {
+    auto &state = global_state->Cast<PostHogRemoteScanGlobalState>();
+
+    if (!state.executed || !state.result_table) {
+        return 0.0;
+    }
+
+    if (state.result_table->num_rows() == 0) {
+        return 100.0;
+    }
+
+    return 100.0 * static_cast<double>(state.current_row) / static_cast<double>(state.result_table->num_rows());
+}
+
+//===----------------------------------------------------------------------===//
+// Get Table Function
+//===----------------------------------------------------------------------===//
+
+TableFunction PostHogRemoteScan::GetFunction() {
+    TableFunction func("posthog_remote_scan", {}, Execute, Bind, InitGlobal, InitLocal);
+    func.projection_pushdown = false; // TODO: Implement projection pushdown
+    func.filter_pushdown = false;     // TODO: Implement filter pushdown
+    func.table_scan_progress = Progress;
+    return func;
+}
+
+} // namespace duckdb

--- a/src/catalog/remote_scan.hpp
+++ b/src/catalog/remote_scan.hpp
@@ -1,0 +1,92 @@
+//===----------------------------------------------------------------------===//
+//                         PostHog DuckDB Extension
+//
+// catalog/remote_scan.hpp
+//
+// Table function for executing remote queries via Flight SQL
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/function/table_function.hpp"
+#include "flight/flight_client.hpp"
+
+namespace duckdb {
+
+class PostHogCatalog;
+
+//===----------------------------------------------------------------------===//
+// Remote Scan Bind Data
+//===----------------------------------------------------------------------===//
+
+struct PostHogRemoteScanBindData : public TableFunctionData {
+    PostHogRemoteScanBindData(PostHogCatalog &catalog, const string &schema_name, const string &table_name);
+
+    PostHogCatalog &catalog;
+    string schema_name;
+    string table_name;
+
+    // Column information (populated during bind)
+    vector<string> column_names;
+    vector<LogicalType> column_types;
+
+    // The query to execute (generated from table name + column projection)
+    string query;
+};
+
+//===----------------------------------------------------------------------===//
+// Remote Scan State
+//===----------------------------------------------------------------------===//
+
+struct PostHogRemoteScanGlobalState : public GlobalTableFunctionState {
+    PostHogRemoteScanGlobalState();
+
+    // Result table from remote execution
+    std::shared_ptr<arrow::Table> result_table;
+
+    // Current position in the result
+    idx_t current_row = 0;
+
+    // Whether we've executed the query
+    bool executed = false;
+
+    idx_t MaxThreads() const override {
+        return 1; // Single-threaded for now
+    }
+};
+
+struct PostHogRemoteScanLocalState : public LocalTableFunctionState {
+    // Nothing needed for now
+};
+
+//===----------------------------------------------------------------------===//
+// Remote Scan Function
+//===----------------------------------------------------------------------===//
+
+class PostHogRemoteScan {
+public:
+    // Get the table function definition
+    static TableFunction GetFunction();
+
+    // Create bind data for a specific table scan
+    static unique_ptr<FunctionData> CreateBindData(PostHogCatalog &catalog, const string &schema_name,
+                                                   const string &table_name, const vector<string> &column_names,
+                                                   const vector<LogicalType> &column_types);
+
+private:
+    // Table function callbacks
+    static unique_ptr<FunctionData> Bind(ClientContext &context, TableFunctionBindInput &input,
+                                         vector<LogicalType> &return_types, vector<string> &names);
+
+    static unique_ptr<GlobalTableFunctionState> InitGlobal(ClientContext &context, TableFunctionInitInput &input);
+
+    static unique_ptr<LocalTableFunctionState> InitLocal(ExecutionContext &context, TableFunctionInitInput &input,
+                                                         GlobalTableFunctionState *global_state);
+
+    static void Execute(ClientContext &context, TableFunctionInput &data, DataChunk &output);
+
+    static double Progress(ClientContext &context, const FunctionData *bind_data,
+                           const GlobalTableFunctionState *global_state);
+};
+
+} // namespace duckdb


### PR DESCRIPTION
Implement the virtual catalog system for remote PostHog databases:

- Add PostHogSchemaEntry class extending SchemaCatalogEntry for remote schemas
- Add PostHogTableEntry class extending TableCatalogEntry for remote tables
- Add remote_scan TableFunction for executing queries via Flight SQL
- Implement lazy loading of schemas and tables from remote server
- Add schema/table caching with 5-minute TTL for performance
- Thread-safe cache operations with mutex protection
- Update PostHogCatalog with ScanSchemas() and LookupSchema() implementation
- Arrow-to-DuckDB type conversion for query results

This enables:
- SHOW SCHEMAS FROM attached_db;
- SHOW TABLES FROM attached_db.schema;
- SELECT * FROM attached_db.schema.table;