### PR TITLE
docs: add Codex Cloud CI tidy-check simulation runbook

### DIFF
--- a/docs/codex_cloud_ci_tidy_run.md
+++ b/docs/codex_cloud_ci_tidy_run.md
@@ -1,0 +1,51 @@
+# Codex Cloud CI Simulation (Tidy Check)
+
+This documents a direct simulation of the `tidy-check` job from `.github/workflows/MainDistributionPipeline.yml` in Codex Cloud.
+
+## Environment
+- `uname -s`: `Linux`
+- `uname -m`: `x86_64`
+- `id -u`: `0`
+
+## Commands run
+
+```bash
+git submodule update --init --recursive
+apt-get update -y -qq
+apt-get install -y -qq ninja-build clang-tidy python3-pip
+pip3 install pybind11[global] --break-system-packages
+```
+
+```bash
+BASELINE="$(python3 - <<'PY'
+import json
+with open('vcpkg-configuration.json','r',encoding='utf-8') as f:
+    print(json.load(f)['default-registry']['baseline'])
+PY
+)"
+rm -rf vcpkg
+git clone https://github.com/microsoft/vcpkg.git vcpkg
+cd vcpkg
+git checkout "$BASELINE"
+./bootstrap-vcpkg.sh -disableMetrics
+```
+
+```bash
+CC=gcc CXX=g++ GEN=ninja TIDY_THREADS=4 \
+VCPKG_TOOLCHAIN_PATH="$PWD/vcpkg/scripts/buildsystems/vcpkg.cmake" \
+VCPKG_TARGET_TRIPLET=x64-linux-release \
+VCPKG_HOST_TRIPLET=x64-linux-release \
+VCPKG_OVERLAY_PORTS="$PWD/extension-ci-tools/vcpkg_ports" \
+VCPKG_OVERLAY_TRIPLETS="$PWD/extension-ci-tools/toolchains" \
+VCPKG_BINARY_SOURCES='clear;http,https://vcpkg-cache.duckdb.org,read' \
+make tidy-check
+```
+
+## Result in this run
+- The job setup completed successfully (submodules, tooling install, vcpkg bootstrap).
+- `make tidy-check` started successfully and entered `vcpkg install` for `x64-linux-release`.
+- The run progressed into dependency compilation (`protobuf`, `openssl`, `grpc`) but did not complete within this iteration.
+
+## Notes
+- Warnings were observed when trying to restore from `https://vcpkg-cache.duckdb.org` (`CONNECT tunnel failed, response 403`), so dependencies were built from source.
+- This significantly increases runtime compared with CI cache hits.


### PR DESCRIPTION
### Motivation
- Capture a reproducible, CI-parity `tidy-check` run that avoids Apple Silicon amd64-emulation issues by running the exact CI steps in a native x86_64 Codex Cloud environment.
- Provide a short runbook and the observed runtime behavior so maintainers can reproduce or triage long-running vcpkg dependency builds that obscure extension tidy results.

### Description
- Added `docs/codex_cloud_ci_tidy_run.md` which documents the exact commands and environment used to simulate the `Tidy Check` job from `.github/workflows/MainDistributionPipeline.yml` on a Linux x86_64 host.
- The runbook includes submodule initialization, tooling installation, vcpkg baseline checkout/bootstrap, CI-matching env variables, and the `make tidy-check` invocation with the vcpkg overlays used by CI.
- The file also records observed runtime behavior (vcpkg cache restore warnings and dependency build progression) so reviewers know why this run may take long or differ from GitHub Actions cached runs.

### Testing
- Ran `git submodule update --init --recursive` and tooling install (`apt-get install -y ninja-build clang-tidy python3-pip`) which completed successfully on the Codex Cloud runner.
- Bootstrapped vcpkg at the repository baseline using the baseline from `vcpkg-configuration.json` and `./bootstrap-vcpkg.sh -disableMetrics`, which completed successfully.
- Launched the CI-parity tidy command using the workflow environment (`CC=gcc CXX=g++ GEN=ninja TIDY_THREADS=4 ... make tidy-check`), which started and entered `vcpkg install` for `x64-linux-release` and progressed through `protobuf`, `openssl`, and `grpc` builds but did not reach final tidy completion in this iteration (dependency builds ran from source due to cache restore warnings).
- Observed warnings when restoring from `https://vcpkg-cache.duckdb.org` (`CONNECT tunnel failed, response 403`), causing full source builds and longer run time; these details are recorded in the runbook.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e43e6fc3083298b0c250de7abb8c8)