### PR TITLE
Fix remote scan row id type and update scalar lookup

### DIFF
--- a/src/catalog/remote_scan.cpp
+++ b/src/catalog/remote_scan.cpp
@@ -144,7 +144,7 @@ unique_ptr<GlobalTableFunctionState> PostHogRemoteScan::InitGlobal(ClientContext
 		result->projection_ids = input.projection_ids;
 		for (const auto &col_idx : input.column_ids) {
 			if (col_idx == COLUMN_IDENTIFIER_ROW_ID) {
-				result->scanned_types.emplace_back(LogicalType::ROW_TYPE);
+				result->scanned_types.emplace_back(LogicalType(LogicalTypeId::BIGINT));
 			} else {
 				result->scanned_types.push_back(bind_data.all_types[col_idx]);
 			}

--- a/src/execution/posthog_update.cpp
+++ b/src/execution/posthog_update.cpp
@@ -119,7 +119,7 @@ SourceResultType PhysicalPostHogUpdate::GetData(ExecutionContext &context, DataC
 				auto out_row = output_chunk.size();
 				output_chunk.SetCardinality(out_row + 1);
 				for (idx_t col_idx = 0; col_idx < GetTypes().size(); col_idx++) {
-					auto scalar_result = combined->column(static_cast<int>(col_idx))->GetScalar(row_idx);
+					auto scalar_result = combined->column(NumericCast<int>(col_idx))->GetScalar(row_idx);
 					if (!scalar_result.ok()) {
 						throw IOException("PostHog: failed to read UPDATE RETURNING scalar: %s",
 						                  scalar_result.status().ToString());


### PR DESCRIPTION
## Summary
- ensure the remote scan treats the special row ID column as a BIGINT rather than ROW_TYPE
- use `NumericCast<int>` when indexing columns during update returning to avoid truncation warnings

## Testing
- Not run (not requested)