### PR TITLE
ci: allow integration tests to fail without blocking pipeline

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -121,6 +121,7 @@ jobs:
   integration-tests:
     name: Integration Tests (DuckLake Pattern)
     runs-on: ubuntu-latest
+    continue-on-error: true
     needs:
       - duckdb-stable-build-main
       - duckdb-stable-build-pr


### PR DESCRIPTION
Adds `continue-on-error: true` to the integration-tests job so downstream failures don't fail the overall CI pipeline. The job still runs and reports status, but won't block merges.