### PR TITLE
Document LLM-first issue-gate workflow and actor-aware in-progress handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,3 +30,14 @@
 - Submodules required: `git submodule update --init --recursive`
 - Dependencies are managed by vcpkg; ensure `VCPKG_TOOLCHAIN_PATH` is set (see `docs/DEVELOPMENT.md`).
 - SQLLogicTest files live under `test/sql`; integration tests use `.test_slow`.
+
+## Skills
+A skill is a set of local instructions to follow that is stored in a `SKILL.md` file.
+
+### Available skills
+- `issue-gate`: GitHub issue preflight workflow for new tasks. Use before starting any new implementation task to create/claim/abort based on issue state. (file: `skills/issue-gate/SKILL.md`)
+
+### Trigger rules
+- Run `$issue-gate` before starting new implementation work.
+- Execute the issue-gate preflight directly with `gh` (per `skills/issue-gate/SKILL.md`) and follow the returned decision contract.
+- Stop task execution on `ABORT_IN_PROGRESS` and `ABORT_UNCERTAIN`.

--- a/skills/issue-gate/SKILL.md
+++ b/skills/issue-gate/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: issue-gate
+description: Enforce GitHub issue preflight before starting implementation work. Use when beginning a new task to match it against open issues, claim an unstarted match, create a new issue when none matches, and abort only when matching is ambiguous or in-progress work belongs to another actor.
+---
+
+# Issue Gate
+
+## Overview
+Run issue preflight before any new implementation task. Keep GitHub Issues as the source of truth and return one decision: `CREATE`, `CLAIM`, `ABORT_IN_PROGRESS`, or `ABORT_UNCERTAIN`.
+
+## Workflow
+1. Prepare inputs:
+- repository (`owner/repo`)
+- actor login
+- task title
+- task body file path
+2. Fetch open issues using `gh`:
+
+```bash
+gh api --paginate "/repos/owner/repo/issues?state=open&per_page=100" | jq -s '
+  add
+  | [ .[]
+      | select(.pull_request | not)
+      | {
+          number: .number,
+          title: .title,
+          body: (.body // ""),
+          url: .html_url,
+          labels: [ .labels[]?.name ],
+          assignees: [ .assignees[]?.login ]
+        }
+    ]'
+```
+
+3. Run qualitative LLM matching using task + open issues and produce `ISSUE_GATE_MATCH_JSON`.
+4. Derive and emit one decision with this contract:
+
+```json
+{
+  "decision": "CREATE|CLAIM|ABORT_IN_PROGRESS|ABORT_UNCERTAIN",
+  "matched_issue_number": 123,
+  "reason": "string",
+  "human_action": "string"
+}
+```
+
+5. Apply gate behavior:
+- `CREATE`: create issue and continue task against the created issue.
+- `CLAIM`: assign actor and set labels, then continue task against the claimed issue.
+- `ABORT_IN_PROGRESS`: stop task and hand off only when the matched issue is in progress and not assigned to the current actor.
+- `ABORT_UNCERTAIN`: stop task and request human triage.
+
+## LLM Matching Input (required)
+Provide qualitative matching from the runtime LLM with `ISSUE_GATE_MATCH_JSON`:
+
+```json
+{
+  "classification": "clear|ambiguous|none",
+  "matched_issue_number": 123,
+  "reason": "short explanation"
+}
+```
+
+Rules:
+- `ISSUE_GATE_MATCH_JSON` is required.
+- Missing or malformed `ISSUE_GATE_MATCH_JSON` returns `ABORT_UNCERTAIN`.
+- `classification=clear` requires a positive integer `matched_issue_number`.
+
+## Decision Mapping
+- `classification=ambiguous` -> `ABORT_UNCERTAIN`.
+- `classification=none` -> `CREATE`.
+- `classification=clear`:
+  - If matched issue is in progress and assigned to someone other than `ACTOR` -> `ABORT_IN_PROGRESS`.
+  - If matched issue is in progress and assigned to `ACTOR` -> `CLAIM`.
+  - If matched issue is not started -> `CLAIM`.
+
+In-progress signal:
+- Issue has label `status:in-progress`, or
+- Issue has one or more assignees.
+
+Ownership rule:
+- If any assignee login equals `ACTOR`, treat issue as owned by current actor and continue (`CLAIM`).
+- If issue is in progress and no assignee matches `ACTOR`, abort (`ABORT_IN_PROGRESS`).
+
+## GH Commands
+- Create issue:
+  - `gh api -X POST "/repos/$REPO/issues" -f "title=$TASK_TITLE" -F "body=@$TASK_BODY_FILE"`
+- Claim issue:
+  - `gh api -X POST "/repos/$REPO/issues/$ISSUE/assignees" -f "assignees[]=$ACTOR"`
+  - `gh api -X POST "/repos/$REPO/issues/$ISSUE/labels" -f "labels[]=status:in-progress" || true`
+  - `gh api -X DELETE "/repos/$REPO/issues/$ISSUE/labels/status:todo" >/dev/null 2>&1 || true`
+
+## References
+- Matching rubric: `references/match-rubric.md`
+- Manual Claude usage: `references/claude-usage.md`

--- a/skills/issue-gate/references/claude-usage.md
+++ b/skills/issue-gate/references/claude-usage.md
@@ -1,0 +1,32 @@
+# Manual LLM Matching Usage
+
+Use this when preparing `ISSUE_GATE_MATCH_JSON` for issue-gate preflight.
+
+## Inputs to Provide the LLM
+- Task title
+- Task body
+- Current actor login
+- Open issues (number, title, body, labels, assignees)
+- Match rubric from `match-rubric.md`
+
+## Required Output JSON
+Return exactly one JSON object:
+
+```json
+{
+  "classification": "clear|ambiguous|none",
+  "matched_issue_number": 123,
+  "reason": "short explanation"
+}
+```
+
+Notes:
+- `matched_issue_number` is required only when `classification` is `clear`.
+- For `ambiguous` or `none`, omit `matched_issue_number` or set it to `null`.
+- Keep `reason` concise and specific.
+
+## Export Example
+
+```bash
+export ISSUE_GATE_MATCH_JSON='{"classification":"clear","matched_issue_number":29,"reason":"Task scope matches RM06 CREATE VIEW remote support."}'
+```

--- a/skills/issue-gate/references/match-rubric.md
+++ b/skills/issue-gate/references/match-rubric.md
@@ -1,0 +1,26 @@
+# Match Rubric
+
+Use this qualitative rubric when mapping a task to open issues.
+
+## Classifications
+- `clear`: one issue is the obvious same work item.
+- `ambiguous`: two or more issues are plausible matches.
+- `none`: no issue plausibly represents the task.
+
+## How to Decide
+1. Compare task title and task body to issue title and body.
+2. Prefer semantic intent over exact wording.
+3. Consider scope, acceptance criteria, and ownership hints.
+4. Ignore closed issues for this workflow; compare against open issues only.
+
+## Tie-Break Guidance
+- If two issues overlap and one is broader while another is precise, prefer the precise issue only when it clearly contains the requested work.
+- If confidence is not clearly one-way, classify as `ambiguous`.
+- Never force a match to avoid creating an issue.
+
+## Required Outcome Mapping
+- `clear` and issue not started -> claim issue.
+- `clear` and issue in progress, assigned to current actor -> claim issue.
+- `clear` and issue in progress, not assigned to current actor -> `ABORT_IN_PROGRESS`.
+- `ambiguous` -> `ABORT_UNCERTAIN` and request human triage.
+- `none` -> create issue.


### PR DESCRIPTION
## Summary
- add an `issue-gate` skill documenting a direct `gh` + LLM preflight workflow
- define required `ISSUE_GATE_MATCH_JSON` contract and decision mapping (`CREATE|CLAIM|ABORT_IN_PROGRESS|ABORT_UNCERTAIN`)
- refine in-progress behavior: abort only when work is in progress and not assigned to the current actor
- add supporting references for matching rubric and manual LLM usage
- wire AGENTS trigger rules to the new skill workflow

## Files
- AGENTS.md
- skills/issue-gate/SKILL.md
- skills/issue-gate/references/match-rubric.md
- skills/issue-gate/references/claude-usage.md

## Testing
- Not run (docs/policy updates only)
