### PR TITLE
Add teardown cleanup for insert_constraint_error_remote test

### DIFF
--- a/test/sql/queries/insert_constraint_error_remote.test_slow
+++ b/test/sql/queries/insert_constraint_error_remote.test_slow
@@ -31,3 +31,7 @@ statement error
 INSERT INTO remote.insert_constraint_error.t VALUES (1, 20);
 ----
 Constraint Error: PostHog: Update execution failed
+
+# Teardown: keep shared remote catalog clean for following integration tests.
+statement ok
+DROP SCHEMA IF EXISTS remote.insert_constraint_error CASCADE;


### PR DESCRIPTION
## Summary
- ensure `insert_constraint_error_remote.test_slow` drops the remote schema after running to prevent interference with other integration tests
- document the teardown intent in the SQL logic file for clarity

## Testing
- Not run (not requested)