### PR TITLE
Remove multi-attach behavior and migrate integration tests

### DIFF
--- a/docs/INTERNAL_API.md
+++ b/docs/INTERNAL_API.md
@@ -9,8 +9,7 @@ It is intended for maintainers and contributors.
   - Registers the `hog:` protocol for `ATTACH`.
   - Parses connection strings and validates required parameters (`user`/`password`).
   - **Single-catalog attach**: if `hog:<catalog>?user=...&password=...` is provided, creates one `PostHogCatalog` for that remote catalog.
-  - **Multi-catalog attach**: if no catalog is provided (`hog:?user=...&password=...`), enumerates remote catalogs via Flight SQL metadata and attaches each as a separate DuckDB database using `<alias>_<catalog>` naming. The primary alias (`AS <alias>`) is a stub catalog with no tables - users must use the prefixed versions for queries.
-  - Uses an internal `__remote_catalog=<catalog>` option when attaching secondary catalogs to avoid re-enumeration.
+  - **Catalog-omitted attach**: if no catalog is provided (`hog:?user=...&password=...`), creates one `PostHogCatalog` with an empty remote-catalog value and relies on server-default catalog resolution.
 
 ## Connection String
 
@@ -32,10 +31,6 @@ It is intended for maintainers and contributors.
 - `PostHogCatalog` (`src/catalog/posthog_catalog.cpp`)
   - Owns the Flight client, connection state, and schema cache.
   - Lazily loads schemas and exposes them via DuckDB's catalog interface.
-
-- `PostHogStubCatalog` (`src/catalog/posthog_stub_catalog.cpp`)
-  - Empty catalog used as the primary alias in multi-catalog mode.
-  - Has no schemas or tables - all operations throw helpful errors directing users to the prefixed catalogs.
 
 - `PostHogSchemaEntry` (`src/catalog/posthog_schema_entry.cpp`)
   - Lazily loads tables for a schema with caching/TTL.

--- a/src/storage/posthog_storage.cpp
+++ b/src/storage/posthog_storage.cpp
@@ -10,15 +10,11 @@
 #include "storage/posthog_storage.hpp"
 #include "storage/posthog_transaction_manager.hpp"
 #include "catalog/posthog_catalog.hpp"
-#include "catalog/posthog_stub_catalog.hpp"
 #include "utils/connection_string.hpp"
 #include "flight/flight_client.hpp"
-#include "duckdb/main/database_manager.hpp"
 #include "duckdb/main/attached_database.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "utils/posthog_logger.hpp"
-
-#include <set>
 
 namespace duckdb {
 
@@ -46,18 +42,6 @@ void ResolveSecurityOptions(PostHogConnectionConfig &config) {
 
 } // namespace
 
-// Helper to enumerate all distinct catalog names from the remote Flight server
-static std::vector<string> EnumerateRemoteCatalogs(PostHogFlightClient &client) {
-	std::set<string> catalog_set;
-	auto schema_infos = client.ListDbSchemas("");
-	for (const auto &info : schema_infos) {
-		if (!info.catalog_name.empty()) {
-			catalog_set.insert(info.catalog_name);
-		}
-	}
-	return std::vector<string>(catalog_set.begin(), catalog_set.end());
-}
-
 static unique_ptr<Catalog> PostHogAttach(optional_ptr<StorageExtensionInfo> storage_info, ClientContext &context,
                                          AttachedDatabase &db, const string &name, AttachInfo &info,
                                          AttachOptions &attach_options) {
@@ -78,90 +62,12 @@ static unique_ptr<Catalog> PostHogAttach(optional_ptr<StorageExtensionInfo> stor
 	}
 	ResolveSecurityOptions(config);
 
-	// Check if this is a secondary catalog attachment (has __remote_catalog parameter)
-	// If so, skip enumeration and just attach this specific catalog
-	auto remote_catalog_it = config.options.find("__remote_catalog");
-	if (remote_catalog_it != config.options.end()) {
-		POSTHOG_LOG_INFO("Attaching secondary remote catalog '%s' as '%s'", remote_catalog_it->second.c_str(),
-		                 name.c_str());
-		return make_uniq<PostHogCatalog>(db, name, std::move(config), remote_catalog_it->second);
-	}
-
-	// If user specified a database/catalog in the connection string, use only that catalog
-	if (!config.database.empty()) {
-		string remote_catalog = config.database;
-		POSTHOG_LOG_INFO("Attaching remote catalog '%s' as '%s'", remote_catalog.c_str(), name.c_str());
-		return make_uniq<PostHogCatalog>(db, name, std::move(config), remote_catalog);
-	}
-
-	// No specific catalog requested: enumerate all remote catalogs and attach them
-	std::vector<string> remote_catalogs;
-	try {
-		PostHogFlightClient temp_client(config.flight_server, config.user, config.password, config.tls_skip_verify);
-		temp_client.Authenticate();
-		remote_catalogs = EnumerateRemoteCatalogs(temp_client);
-	} catch (const std::exception &e) {
-		// If we can't connect, fall back to single catalog mode with empty remote_catalog
-		POSTHOG_LOG_WARN("Failed to enumerate remote catalogs: %s. Using single catalog mode.", e.what());
-		return make_uniq<PostHogCatalog>(db, name, std::move(config), "");
-	}
-
-	if (remote_catalogs.empty()) {
-		// No catalogs found, use empty remote_catalog
-		POSTHOG_LOG_WARN("No remote catalogs found. Using single catalog mode.");
-		return make_uniq<PostHogCatalog>(db, name, std::move(config), "");
-	}
-
-	// Attach ALL remote catalogs with <name>_<catalog> naming convention
-	auto &db_manager = DatabaseManager::Get(context);
-	for (const string &remote_catalog : remote_catalogs) {
-		string local_db_name = name + "_" + remote_catalog;
-
-		// Check if this database is already attached
-		if (db_manager.GetDatabase(context, local_db_name)) {
-			POSTHOG_LOG_DEBUG("Database '%s' already attached, skipping.", local_db_name.c_str());
-			continue;
-		}
-
-		POSTHOG_LOG_INFO("Attaching remote catalog '%s' as '%s'", remote_catalog.c_str(), local_db_name.c_str());
-
-		// Create AttachInfo for the catalog
-		AttachInfo additional_info;
-		additional_info.path = info.path;
-		// Add the remote_catalog as a query parameter
-		if (additional_info.path.find('?') == string::npos) {
-			additional_info.path += "?";
-		} else {
-			additional_info.path += "&";
-		}
-		additional_info.path += "__remote_catalog=" + remote_catalog;
-		additional_info.name = local_db_name;
-
-		// Create AttachOptions
-		unordered_map<string, Value> opts;
-		opts["type"] = Value("hog");
-		AttachOptions additional_options(opts, attach_options.access_mode);
-
-		try {
-			auto attached_db = db_manager.AttachDatabase(context, additional_info, additional_options);
-			if (!attached_db) {
-				continue;
-			}
-
-			// DuckDB 1.4.x requires explicit initialize/finalize/finalize-attach when
-			// using DatabaseManager::AttachDatabase directly.
-			attached_db->Initialize(context);
-			attached_db->FinalizeLoad(context);
-			db_manager.FinalizeAttach(context, additional_info, std::move(attached_db));
-		} catch (const std::exception &e) {
-			POSTHOG_LOG_ERROR("Failed to attach catalog '%s': %s", remote_catalog.c_str(), e.what());
-		}
-	}
-
-	// Return a stub catalog for the primary attachment (required by DuckDB)
-	// The stub catalog has no tables - users should use the prefixed catalogs instead
-	POSTHOG_LOG_INFO("Attaching stub catalog as '%s' (use '%s_<catalog>' for queries)", name.c_str(), name.c_str());
-	return make_uniq<PostHogStubCatalog>(db, name);
+	// Attach exactly one catalog.
+	// If `config.database` is empty (e.g. hog:?user=...), the server resolves
+	// the default catalog semantics.
+	string remote_catalog = config.database;
+	POSTHOG_LOG_INFO("Attaching remote catalog '%s' as '%s'", remote_catalog.c_str(), name.c_str());
+	return make_uniq<PostHogCatalog>(db, name, std::move(config), remote_catalog);
 }
 
 static unique_ptr<TransactionManager> PostHogCreateTransactionManager(optional_ptr<StorageExtensionInfo> storage_info,

--- a/test/sql/integration/join_cross_catalog_remote.test_slow
+++ b/test/sql/integration/join_cross_catalog_remote.test_slow
@@ -18,7 +18,7 @@ statement ok
 ATTACH 'hog:ducklake?user=${DUCKHOG_USER}&password=${DUCKHOG_PASSWORD}&flight_server=grpc+tls://${FLIGHT_HOST}:${FLIGHT_PORT}&tls_skip_verify=true' AS remote_flight;
 
 statement ok
-ATTACH 'hog:?user=${DUCKHOG_USER}&password=${DUCKHOG_PASSWORD}&flight_server=grpc+tls://${FLIGHT_HOST}:${FLIGHT_PORT}&tls_skip_verify=true' AS remote_multi;
+ATTACH 'hog:memory?user=${DUCKHOG_USER}&password=${DUCKHOG_PASSWORD}&flight_server=grpc+tls://${FLIGHT_HOST}:${FLIGHT_PORT}&tls_skip_verify=true' AS remote_mem;
 
 statement ok
 DROP SCHEMA IF EXISTS remote_flight.cross_cat CASCADE;
@@ -28,10 +28,10 @@ CREATE SCHEMA remote_flight.cross_cat;
 
 # Clean up memory catalog tables from prior runs
 statement ok
-DROP TABLE IF EXISTS remote_multi_memory.customers;
+DROP TABLE IF EXISTS remote_mem.customers;
 
 statement ok
-DROP TABLE IF EXISTS remote_multi_memory.from_ducklake;
+DROP TABLE IF EXISTS remote_mem.from_ducklake;
 
 # ============================================================
 # Setup: tables in DuckLake, memory remote, and local
@@ -48,10 +48,10 @@ INSERT INTO remote_flight.cross_cat.orders VALUES
     (4, 300, 30.0);
 
 statement ok
-CREATE TABLE remote_multi_memory.customers(customer_id INT, name VARCHAR);
+CREATE TABLE remote_mem.customers(customer_id INT, name VARCHAR);
 
 statement ok
-INSERT INTO remote_multi_memory.customers VALUES
+INSERT INTO remote_mem.customers VALUES
     (100, 'alice'),
     (200, 'bob'),
     (400, 'dave');
@@ -97,18 +97,16 @@ ORDER BY o.order_id;
 # JOIN between two different remote catalogs (ducklake + memory)
 # ============================================================
 
-# DuckHog limitation: cross-catalog JOINs between two remote catalogs
-# that share the same Flight server fail with "transaction already active"
-# because both catalogs try to begin a transaction on the same connection.
-# This is a known limitation — document with error test.
-
-statement error
+# Cross-catalog JOIN between two explicitly attached remote catalogs.
+query ITRI
 SELECT c.customer_id, c.name, o.amount, o.order_id
-FROM remote_multi_memory.customers c
+FROM remote_mem.customers c
 INNER JOIN remote_flight.cross_cat.orders o ON c.customer_id = o.customer_id
 ORDER BY o.order_id;
 ----
-transaction already active
+100	alice	50.0	1
+100	alice	75.0	2
+200	bob	120.0	3
 
 # ============================================================
 # INSERT...SELECT from local table to remote table
@@ -134,29 +132,34 @@ SELECT x, v FROM remote_flight.cross_cat.from_local ORDER BY x;
 
 # ============================================================
 # INSERT...SELECT from one remote catalog to another
-# Same "transaction already active" limitation as cross-catalog JOINs.
+# Works with explicit single-catalog attaches.
 # ============================================================
 
 statement ok
-CREATE TABLE remote_multi_memory.from_ducklake(order_id INT, amount DOUBLE);
+CREATE TABLE remote_mem.from_ducklake(order_id INT, amount DOUBLE);
 
-statement error
-INSERT INTO remote_multi_memory.from_ducklake
+statement ok
+INSERT INTO remote_mem.from_ducklake
     SELECT order_id, amount FROM remote_flight.cross_cat.orders WHERE amount > 50;
+
+query IR
+SELECT order_id, amount FROM remote_mem.from_ducklake ORDER BY order_id;
 ----
-transaction already active
+2	75.0
+3	120.0
 
 # ============================================================
-# Subquery referencing both remote catalogs — same limitation
+# Subquery referencing both remote catalogs
 # ============================================================
 
-statement error
+query IR
 SELECT order_id, amount
 FROM remote_flight.cross_cat.orders
-WHERE customer_id IN (SELECT customer_id FROM remote_multi_memory.customers WHERE name = 'alice')
+WHERE customer_id IN (SELECT customer_id FROM remote_mem.customers WHERE name = 'alice')
 ORDER BY order_id;
 ----
-transaction already active
+1	50.0
+2	75.0
 
 # ============================================================
 # Subquery with local + single remote works fine
@@ -182,7 +185,7 @@ statement ok
 DROP TABLE local_cust_ids;
 
 # ============================================================
-# Three-way join: local + ducklake + memory — same limitation
+# Three-way join: local + ducklake + memory
 # ============================================================
 
 statement ok
@@ -191,14 +194,16 @@ CREATE TABLE local_tags(order_id INT, tag VARCHAR);
 statement ok
 INSERT INTO local_tags VALUES (1, 'priority'), (2, 'normal'), (3, 'priority');
 
-statement error
+query TTRI
 SELECT c.name, lt.tag, o.amount, o.order_id
 FROM remote_flight.cross_cat.orders o
-INNER JOIN remote_multi_memory.customers c ON o.customer_id = c.customer_id
+INNER JOIN remote_mem.customers c ON o.customer_id = c.customer_id
 INNER JOIN local_tags lt ON o.order_id = lt.order_id
 ORDER BY o.order_id;
 ----
-transaction already active
+alice	priority	50.0	1
+alice	normal	75.0	2
+bob	priority	120.0	3
 
 # ============================================================
 # Cleanup
@@ -217,10 +222,10 @@ statement ok
 DROP TABLE IF EXISTS local_tags;
 
 statement ok
-DROP TABLE IF EXISTS remote_multi_memory.customers;
+DROP TABLE IF EXISTS remote_mem.customers;
 
 statement ok
-DROP TABLE IF EXISTS remote_multi_memory.from_ducklake;
+DROP TABLE IF EXISTS remote_mem.from_ducklake;
 
 statement ok
 DROP SCHEMA remote_flight.cross_cat CASCADE;

--- a/test/sql/integration/multi_catalog_schemas.test_slow
+++ b/test/sql/integration/multi_catalog_schemas.test_slow
@@ -1,5 +1,5 @@
 # name: test/sql/integration/multi_catalog_schemas.test_slow
-# description: Test multi-catalog auto-discovery when no database is specified
+# description: Test catalog-less attach does not auto-attach additional catalogs
 # group: [integration]
 
 # Tests in this file require a running Flight SQL server
@@ -16,47 +16,30 @@ require-env DUCKHOG_USER
 require-env DUCKHOG_PASSWORD
 
 # When no catalog is specified in the connection string, the extension
-# auto-discovers all remote catalogs from the Flight server.
-# Discovered catalogs use the prefix pattern: <alias>_<catalog_name>.
+# attaches a single catalog under the requested alias. It should not
+# auto-attach additional <alias>_<catalog> entries.
 statement ok
 ATTACH 'hog:?user=${DUCKHOG_USER}&password=${DUCKHOG_PASSWORD}&flight_server=grpc+tls://${FLIGHT_HOST}:${FLIGHT_PORT}&tls_skip_verify=true' AS remote;
 
-# Verify remote_memory has the 'main' schema
-query I
-SELECT COUNT(*) FROM information_schema.schemata WHERE catalog_name = 'remote_memory' AND schema_name = 'main';
-----
-1
-
-# Ensure the primary data catalog has working table access
-
-query I
-SELECT CASE WHEN COUNT(*) > 0 THEN 1 ELSE 0 END FROM remote_memory.main.pg_type;
-----
-1
-
-# The primary alias 'remote' is a stub catalog with no tables.
-# Verify it has no schemas in information_schema
-query I
-SELECT COUNT(*) FROM information_schema.schemata WHERE catalog_name = 'remote';
-----
-0
-
-# The stub catalog still appears in duckdb_databases (not hidden)
-# This is a DuckDB limitation - storage extensions can't hide the primary attachment
+# Primary alias should exist
 query I
 SELECT COUNT(*) FROM duckdb_databases() WHERE database_name = 'remote';
 ----
 1
 
-# Attempting to query the stub catalog should fail with a helpful error message
-statement error
-SELECT * FROM remote.main.pg_type;
+# Auto-attached alias entries should not exist
+query I
+SELECT COUNT(*) FROM duckdb_databases() WHERE database_name LIKE 'remote_%';
 ----
-PostHog: 'remote' is a stub catalog with no tables. Use 'remote_<catalog>' instead
+0
 
-# Cleanup: detach known catalogs
-statement ok
-DETACH remote_memory;
+# Primary alias should expose schemas/tables (i.e. not be a stub catalog)
+query I
+SELECT CASE WHEN COUNT(*) > 0 THEN 1 ELSE 0 END
+FROM information_schema.schemata
+WHERE catalog_name = 'remote';
+----
+1
 
 statement ok
 DETACH remote;

--- a/test/sql/integration/partition_insert_remote.test_slow
+++ b/test/sql/integration/partition_insert_remote.test_slow
@@ -16,9 +16,9 @@ require-env DUCKHOG_PASSWORD
 statement ok
 ATTACH 'hog:ducklake?user=${DUCKHOG_USER}&password=${DUCKHOG_PASSWORD}&flight_server=grpc+tls://${FLIGHT_HOST}:${FLIGHT_PORT}&tls_skip_verify=true' AS remote_flight;
 
-# Multi-catalog attach for metadata inspection
+# Explicit metadata-catalog attach for metadata inspection
 statement ok
-ATTACH 'hog:?user=${DUCKHOG_USER}&password=${DUCKHOG_PASSWORD}&flight_server=grpc+tls://${FLIGHT_HOST}:${FLIGHT_PORT}&tls_skip_verify=true' AS remote;
+ATTACH 'hog:__ducklake_metadata_ducklake?user=${DUCKHOG_USER}&password=${DUCKHOG_PASSWORD}&flight_server=grpc+tls://${FLIGHT_HOST}:${FLIGHT_PORT}&tls_skip_verify=true' AS remote_meta;
 
 statement ok
 DROP SCHEMA IF EXISTS remote_flight.part_rm08 CASCADE;
@@ -65,10 +65,10 @@ SELECT part_key, v FROM remote_flight.part_rm08.t WHERE part_key = 2;
 
 query IT
 SELECT pc.partition_key_index, pc.transform
-FROM remote___ducklake_metadata_ducklake.public.ducklake_partition_column pc
+FROM remote_meta.public.ducklake_partition_column pc
 WHERE pc.table_id = (
-    SELECT MAX(t.table_id) FROM remote___ducklake_metadata_ducklake.public.ducklake_table t
-    JOIN remote___ducklake_metadata_ducklake.public.ducklake_schema s ON t.schema_id = s.schema_id
+    SELECT MAX(t.table_id) FROM remote_meta.public.ducklake_table t
+    JOIN remote_meta.public.ducklake_schema s ON t.schema_id = s.schema_id
     WHERE s.schema_name = 'part_rm08' AND t.table_name = 't'
 );
 ----
@@ -78,10 +78,10 @@ WHERE pc.table_id = (
 
 query T
 SELECT DISTINCT fpv.partition_value
-FROM remote___ducklake_metadata_ducklake.public.ducklake_file_partition_value fpv
+FROM remote_meta.public.ducklake_file_partition_value fpv
 WHERE fpv.table_id = (
-    SELECT MAX(t.table_id) FROM remote___ducklake_metadata_ducklake.public.ducklake_table t
-    JOIN remote___ducklake_metadata_ducklake.public.ducklake_schema s ON t.schema_id = s.schema_id
+    SELECT MAX(t.table_id) FROM remote_meta.public.ducklake_table t
+    JOIN remote_meta.public.ducklake_schema s ON t.schema_id = s.schema_id
     WHERE s.schema_name = 'part_rm08' AND t.table_name = 't'
 )
 ORDER BY fpv.partition_value;
@@ -109,10 +109,10 @@ SELECT part_key, v FROM remote_flight.part_rm08.t ORDER BY part_key, v;
 
 query T
 SELECT DISTINCT fpv.partition_value
-FROM remote___ducklake_metadata_ducklake.public.ducklake_file_partition_value fpv
+FROM remote_meta.public.ducklake_file_partition_value fpv
 WHERE fpv.table_id = (
-    SELECT MAX(t.table_id) FROM remote___ducklake_metadata_ducklake.public.ducklake_table t
-    JOIN remote___ducklake_metadata_ducklake.public.ducklake_schema s ON t.schema_id = s.schema_id
+    SELECT MAX(t.table_id) FROM remote_meta.public.ducklake_table t
+    JOIN remote_meta.public.ducklake_schema s ON t.schema_id = s.schema_id
     WHERE s.schema_name = 'part_rm08' AND t.table_name = 't'
 )
 ORDER BY fpv.partition_value;
@@ -238,10 +238,10 @@ us	2024	100.0
 
 query IT
 SELECT pc.partition_key_index, pc.transform
-FROM remote___ducklake_metadata_ducklake.public.ducklake_partition_column pc
+FROM remote_meta.public.ducklake_partition_column pc
 WHERE pc.table_id = (
-    SELECT MAX(t.table_id) FROM remote___ducklake_metadata_ducklake.public.ducklake_table t
-    JOIN remote___ducklake_metadata_ducklake.public.ducklake_schema s ON t.schema_id = s.schema_id
+    SELECT MAX(t.table_id) FROM remote_meta.public.ducklake_table t
+    JOIN remote_meta.public.ducklake_schema s ON t.schema_id = s.schema_id
     WHERE s.schema_name = 'part_rm08' AND t.table_name = 'multi'
 )
 ORDER BY pc.partition_key_index;
@@ -276,10 +276,10 @@ INSERT INTO remote_flight.part_rm08.resettable VALUES (1, 'before_reset'), (2, '
 
 query IT
 SELECT pc.partition_key_index, pc.transform
-FROM remote___ducklake_metadata_ducklake.public.ducklake_partition_column pc
+FROM remote_meta.public.ducklake_partition_column pc
 WHERE pc.table_id = (
-    SELECT MAX(t.table_id) FROM remote___ducklake_metadata_ducklake.public.ducklake_table t
-    JOIN remote___ducklake_metadata_ducklake.public.ducklake_schema s ON t.schema_id = s.schema_id
+    SELECT MAX(t.table_id) FROM remote_meta.public.ducklake_table t
+    JOIN remote_meta.public.ducklake_schema s ON t.schema_id = s.schema_id
     WHERE s.schema_name = 'part_rm08' AND t.table_name = 'resettable'
 );
 ----
@@ -296,10 +296,10 @@ ALTER TABLE remote_flight.part_rm08.resettable RESET PARTITIONED BY;
 
 query IT
 SELECT pc.partition_key_index, pc.transform
-FROM remote___ducklake_metadata_ducklake.public.ducklake_partition_column pc
+FROM remote_meta.public.ducklake_partition_column pc
 WHERE pc.table_id = (
-    SELECT MAX(t.table_id) FROM remote___ducklake_metadata_ducklake.public.ducklake_table t
-    JOIN remote___ducklake_metadata_ducklake.public.ducklake_schema s ON t.schema_id = s.schema_id
+    SELECT MAX(t.table_id) FROM remote_meta.public.ducklake_table t
+    JOIN remote_meta.public.ducklake_schema s ON t.schema_id = s.schema_id
     WHERE s.schema_name = 'part_rm08' AND t.table_name = 'resettable'
 );
 ----
@@ -349,10 +349,10 @@ SELECT pk, val FROM remote_flight.part_rm08.resettable ORDER BY pk;
 
 query I
 SELECT COUNT(*)
-FROM remote___ducklake_metadata_ducklake.public.ducklake_partition_column pc
+FROM remote_meta.public.ducklake_partition_column pc
 WHERE pc.table_id = (
-    SELECT MAX(t.table_id) FROM remote___ducklake_metadata_ducklake.public.ducklake_table t
-    JOIN remote___ducklake_metadata_ducklake.public.ducklake_schema s ON t.schema_id = s.schema_id
+    SELECT MAX(t.table_id) FROM remote_meta.public.ducklake_table t
+    JOIN remote_meta.public.ducklake_schema s ON t.schema_id = s.schema_id
     WHERE s.schema_name = 'part_rm08' AND t.table_name = 'resettable'
 );
 ----
@@ -436,10 +436,10 @@ SELECT COUNT(*) FROM remote_flight.part_rm08.str_part WHERE category = 'food';
 
 query T
 SELECT DISTINCT fpv.partition_value
-FROM remote___ducklake_metadata_ducklake.public.ducklake_file_partition_value fpv
+FROM remote_meta.public.ducklake_file_partition_value fpv
 WHERE fpv.table_id = (
-    SELECT MAX(t.table_id) FROM remote___ducklake_metadata_ducklake.public.ducklake_table t
-    JOIN remote___ducklake_metadata_ducklake.public.ducklake_schema s ON t.schema_id = s.schema_id
+    SELECT MAX(t.table_id) FROM remote_meta.public.ducklake_table t
+    JOIN remote_meta.public.ducklake_schema s ON t.schema_id = s.schema_id
     WHERE s.schema_name = 'part_rm08' AND t.table_name = 'str_part'
 )
 ORDER BY fpv.partition_value;
@@ -573,4 +573,4 @@ statement ok
 DROP SCHEMA remote_flight.part_rm08 CASCADE;
 
 statement ok
-DETACH remote;
+DETACH remote_meta;

--- a/test/sql/integration/returning_types_remote.test_slow
+++ b/test/sql/integration/returning_types_remote.test_slow
@@ -212,21 +212,21 @@ CTE needs a SELECT
 # ============================================================
 
 statement ok
-ATTACH 'hog:?user=${DUCKHOG_USER}&password=${DUCKHOG_PASSWORD}&flight_server=grpc+tls://${FLIGHT_HOST}:${FLIGHT_PORT}&tls_skip_verify=true' AS remote_ret_mem;
+ATTACH 'hog:memory?user=${DUCKHOG_USER}&password=${DUCKHOG_PASSWORD}&flight_server=grpc+tls://${FLIGHT_HOST}:${FLIGHT_PORT}&tls_skip_verify=true' AS remote_ret_mem;
 
 statement ok
-DROP TABLE IF EXISTS remote_ret_mem_memory.unsigned_ret;
+DROP TABLE IF EXISTS remote_ret_mem.unsigned_ret;
 
 statement ok
-CREATE TABLE remote_ret_mem_memory.unsigned_ret(uti UTINYINT, usi USMALLINT, ui UINTEGER, ubi UBIGINT);
+CREATE TABLE remote_ret_mem.unsigned_ret(uti UTINYINT, usi USMALLINT, ui UINTEGER, ubi UBIGINT);
 
 query IIII
-INSERT INTO remote_ret_mem_memory.unsigned_ret VALUES (255, 65535, 4294967295, 18446744073709551615) RETURNING *;
+INSERT INTO remote_ret_mem.unsigned_ret VALUES (255, 65535, 4294967295, 18446744073709551615) RETURNING *;
 ----
 255	65535	4294967295	18446744073709551615
 
 query IIII
-INSERT INTO remote_ret_mem_memory.unsigned_ret VALUES (0, 0, 0, 0) RETURNING *;
+INSERT INTO remote_ret_mem.unsigned_ret VALUES (0, 0, 0, 0) RETURNING *;
 ----
 0	0	0	0
 
@@ -235,7 +235,7 @@ INSERT INTO remote_ret_mem_memory.unsigned_ret VALUES (0, 0, 0, 0) RETURNING *;
 # ============================================================
 
 statement ok
-DROP TABLE IF EXISTS remote_ret_mem_memory.unsigned_ret;
+DROP TABLE IF EXISTS remote_ret_mem.unsigned_ret;
 
 statement ok
 DROP SCHEMA remote_flight.ret_types CASCADE;

--- a/test/sql/integration/select_types_remote.test_slow
+++ b/test/sql/integration/select_types_remote.test_slow
@@ -56,13 +56,13 @@ NULL	NULL	NULL	NULL
 # Testing on memory catalog to verify Arrow Flight roundtrip.
 
 statement ok
-ATTACH 'hog:?user=${DUCKHOG_USER}&password=${DUCKHOG_PASSWORD}&flight_server=grpc+tls://${FLIGHT_HOST}:${FLIGHT_PORT}&tls_skip_verify=true' AS remote_u;
+ATTACH 'hog:memory?user=${DUCKHOG_USER}&password=${DUCKHOG_PASSWORD}&flight_server=grpc+tls://${FLIGHT_HOST}:${FLIGHT_PORT}&tls_skip_verify=true' AS remote_u;
 
 statement ok
-DROP TABLE IF EXISTS remote_u_memory.unsigned_test;
+DROP TABLE IF EXISTS remote_u.unsigned_test;
 
 statement ok
-CREATE TABLE remote_u_memory.unsigned_test(
+CREATE TABLE remote_u.unsigned_test(
     uti UTINYINT,
     usi USMALLINT,
     ui UINTEGER,
@@ -70,13 +70,13 @@ CREATE TABLE remote_u_memory.unsigned_test(
 );
 
 statement ok
-INSERT INTO remote_u_memory.unsigned_test VALUES
+INSERT INTO remote_u.unsigned_test VALUES
     (0, 0, 0, 0),
     (255, 65535, 4294967295, 18446744073709551615),
     (NULL, NULL, NULL, NULL);
 
 query IIII
-SELECT uti, usi, ui, ubi FROM remote_u_memory.unsigned_test ORDER BY uti NULLS LAST;
+SELECT uti, usi, ui, ubi FROM remote_u.unsigned_test ORDER BY uti NULLS LAST;
 ----
 0	0	0	0
 255	65535	4294967295	18446744073709551615
@@ -377,4 +377,4 @@ statement ok
 DROP SCHEMA remote_flight.type_test CASCADE;
 
 statement ok
-DROP TABLE IF EXISTS remote_u_memory.unsigned_test;
+DROP TABLE IF EXISTS remote_u.unsigned_test;

--- a/test/sql/integration/transaction_multi_op_remote.test_slow
+++ b/test/sql/integration/transaction_multi_op_remote.test_slow
@@ -163,27 +163,27 @@ SELECT * FROM remote_flight.txn_test.ddl_dml_rb;
 # ============================================================
 
 statement ok
-ATTACH 'hog:?user=${DUCKHOG_USER}&password=${DUCKHOG_PASSWORD}&flight_server=grpc+tls://${FLIGHT_HOST}:${FLIGHT_PORT}&tls_skip_verify=true' AS remote_mem_txn;
+ATTACH 'hog:memory?user=${DUCKHOG_USER}&password=${DUCKHOG_PASSWORD}&flight_server=grpc+tls://${FLIGHT_HOST}:${FLIGHT_PORT}&tls_skip_verify=true' AS remote_mem_txn;
 
 statement ok
-DROP TABLE IF EXISTS remote_mem_txn_memory.err_test;
+DROP TABLE IF EXISTS remote_mem_txn.err_test;
 
 statement ok
-CREATE TABLE remote_mem_txn_memory.err_test(id INT PRIMARY KEY, val VARCHAR);
+CREATE TABLE remote_mem_txn.err_test(id INT PRIMARY KEY, val VARCHAR);
 
 statement ok
-INSERT INTO remote_mem_txn_memory.err_test VALUES (1, 'first');
+INSERT INTO remote_mem_txn.err_test VALUES (1, 'first');
 
 statement ok
 BEGIN;
 
 # This succeeds
 statement ok
-INSERT INTO remote_mem_txn_memory.err_test VALUES (2, 'second');
+INSERT INTO remote_mem_txn.err_test VALUES (2, 'second');
 
 # This should fail — duplicate PK
 statement error
-INSERT INTO remote_mem_txn_memory.err_test VALUES (1, 'duplicate');
+INSERT INTO remote_mem_txn.err_test VALUES (1, 'duplicate');
 ----
 
 statement ok
@@ -191,7 +191,7 @@ ROLLBACK;
 
 # After rollback, only original row should exist
 query IT
-SELECT id, val FROM remote_mem_txn_memory.err_test ORDER BY id;
+SELECT id, val FROM remote_mem_txn.err_test ORDER BY id;
 ----
 1	first
 
@@ -271,7 +271,7 @@ SELECT id, val FROM remote_flight.txn_test.interleave ORDER BY id;
 # ============================================================
 
 statement ok
-DROP TABLE IF EXISTS remote_mem_txn_memory.err_test;
+DROP TABLE IF EXISTS remote_mem_txn.err_test;
 
 statement ok
 DROP SCHEMA remote_flight.txn_test CASCADE;

--- a/test/sql/integration/unsupported_operations_remote.test_slow
+++ b/test/sql/integration/unsupported_operations_remote.test_slow
@@ -78,29 +78,29 @@ UPDATE ... RETURNING is not yet supported
 # Test with memory catalog instead.
 
 statement ok
-ATTACH 'hog:?user=${DUCKHOG_USER}&password=${DUCKHOG_PASSWORD}&flight_server=grpc+tls://${FLIGHT_HOST}:${FLIGHT_PORT}&tls_skip_verify=true' AS remote_unsup_mem;
+ATTACH 'hog:memory?user=${DUCKHOG_USER}&password=${DUCKHOG_PASSWORD}&flight_server=grpc+tls://${FLIGHT_HOST}:${FLIGHT_PORT}&tls_skip_verify=true' AS remote_unsup_mem;
 
 statement ok
-DROP TABLE IF EXISTS remote_unsup_mem_memory.pk_table;
+DROP TABLE IF EXISTS remote_unsup_mem.pk_table;
 
 statement ok
-CREATE TABLE remote_unsup_mem_memory.pk_table(id INT PRIMARY KEY, val VARCHAR);
+CREATE TABLE remote_unsup_mem.pk_table(id INT PRIMARY KEY, val VARCHAR);
 
 statement ok
-INSERT INTO remote_unsup_mem_memory.pk_table VALUES (1, 'original');
+INSERT INTO remote_unsup_mem.pk_table VALUES (1, 'original');
 
 # DO UPDATE should error — but the binder can't see the PK constraint
 # (DuckHog metadata sync gap), so the error comes from the binder, not
 # our ON CONFLICT code path.
 statement error
-INSERT INTO remote_unsup_mem_memory.pk_table VALUES (1, 'conflict')
+INSERT INTO remote_unsup_mem.pk_table VALUES (1, 'conflict')
     ON CONFLICT (id) DO UPDATE SET val = EXCLUDED.val;
 ----
 not referenced by a UNIQUE/PRIMARY KEY CONSTRAINT
 
 # Same binder error for DO NOTHING with explicit conflict target
 statement error
-INSERT INTO remote_unsup_mem_memory.pk_table VALUES (1, 'conflict')
+INSERT INTO remote_unsup_mem.pk_table VALUES (1, 'conflict')
     ON CONFLICT (id) DO NOTHING RETURNING *;
 ----
 not referenced by a UNIQUE/PRIMARY KEY CONSTRAINT
@@ -134,33 +134,11 @@ DROP SEQUENCE remote_flight.unsup_test.nonexistent;
 ----
 
 # ============================================================
-# Stub catalog operations
-# ============================================================
-
-statement ok
-ATTACH 'hog:?user=${DUCKHOG_USER}&password=${DUCKHOG_PASSWORD}&flight_server=grpc+tls://${FLIGHT_HOST}:${FLIGHT_PORT}&tls_skip_verify=true' AS remote_stub;
-
-statement error
-CREATE SCHEMA remote_stub.test;
-----
-Cannot create schema on
-
-statement error
-INSERT INTO remote_stub.nonexistent VALUES (1);
-----
-stub catalog
-
-statement error
-CREATE TABLE remote_stub.test_table(id INT);
-----
-stub catalog
-
-# ============================================================
 # Cleanup
 # ============================================================
 
 statement ok
-DROP TABLE IF EXISTS remote_unsup_mem_memory.pk_table;
+DROP TABLE IF EXISTS remote_unsup_mem.pk_table;
 
 statement ok
 DROP SCHEMA remote_flight.unsup_test CASCADE;


### PR DESCRIPTION
## Summary
- remove multi-attach logic from `PostHogAttach`; `hog:?...` now performs a single attach
- update integration tests to stop depending on auto-attached `remote_<catalog>` aliases
- remove stub-catalog/multi-attach-only assertions and align docs with single-attach behavior

## Testing
- `make format-fix`
- `make tidy-check`
- `./build/release/test/unittest "test/sql/integration/*"`

Closes #65
