### PR TITLE
Fix remote default metadata handling for INSERT DEFAULT values

### DIFF
--- a/test/sql/integration/insert_defaults_returning_remote.test_slow
+++ b/test/sql/integration/insert_defaults_returning_remote.test_slow
@@ -164,11 +164,11 @@ INSERT INTO remote_flight.rm20_22.t(i) VALUES (1) RETURNING *;
 ----
 INSERT ... RETURNING with omitted/default columns is not yet implemented
 
-# Explicit DEFAULT literal + RETURNING
-statement error
+# Explicit DEFAULT literal + RETURNING with full column list is now supported
+query IIT
 INSERT INTO remote_flight.rm20_22.t(i, j, v) VALUES (DEFAULT, DEFAULT, DEFAULT) RETURNING *;
 ----
-INSERT ... RETURNING with omitted/default columns is not yet implemented
+42	7	hello
 
 # ============================================================
 # Full column list + RETURNING still works (no defaults involved)


### PR DESCRIPTION
## Summary
- preserve known column defaults when refreshing PostHog table metadata after remote `CREATE TABLE` and `ALTER TABLE`
- make default propagation safer by skipping copy when source/target column types differ
- remove unsynchronized `table_cache_` access in `Alter` by taking `tables_mutex_` before reading the cache
- update integration expectation for explicit `DEFAULT ... RETURNING` with full column list

## Testing
- `make format-fix`
- `make tidy-check`
- `./test/run_full_suite.sh "test/sql/integration/insert_defaults_returning_remote.test_slow"`

Closes #80
