### PR TITLE
Remove ON CONFLICT roadmap items (RM16, RM17, RM19)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,7 @@ A skill is a set of local instructions to follow that is stored in a `SKILL.md` 
 ### Available skills
 - `issue-gate`: GitHub issue preflight workflow for new tasks. Use before starting any new implementation task to create/claim/abort based on issue state. (file: `skills/issue-gate/SKILL.md`)
 - `red-team`: SQL injection and input validation audit for the DuckHog SQL proxy pipeline. Use after modifying any rewriter, serializer, or SQL-generation code. (file: `skills/red-team/SKILL.md`)
+- `bug-verification`: Rigorous bug verification before filing issues. Determines provenance (upstream vs DuckHog), severity, and catalog-specific attribution. Use whenever a test failure or suspected regression needs classification. (file: `skills/bug-verification/SKILL.md`)
 
 ### Trigger rules
 - Run `$issue-gate` before starting new implementation work.

--- a/skills/bug-verification/SKILL.md
+++ b/skills/bug-verification/SKILL.md
@@ -161,6 +161,27 @@ Add the bug to `docs/RELATED_BUGS.md` using the established format:
 Include: component, severity, reproduction SQL, root cause analysis,
 verification method, workaround, and test file reference.
 
+## Catalog-Aware Attribution
+
+When retiring roadmap items, closing issues, or documenting limitations, always
+verify **which catalog** the test or reproduction uses. Capabilities differ:
+
+| Catalog | PK/UNIQUE | RETURNING | ON CONFLICT | STRUCT/MAP |
+|---------|-----------|-----------|-------------|------------|
+| `hog:memory` | Yes (server-side) | No | Blocked by L2 | TBD |
+| `hog:ducklake` | Never ([ducklake#66](https://github.com/duckdb/ducklake/issues/66)) | No | Never | TBD |
+
+A feature blocked on `hog:ducklake` may still be viable on `hog:memory` (or vice
+versa). Attribute the blocker to the correct layer:
+
+- **L2 (metadata sync)**: Local binder can't see server-side constraints → blocks ON CONFLICT on *both* catalogs
+- **DuckLake limitation**: Server doesn't support the feature at all → blocks only DuckLake catalogs
+- **Duckgres/Arrow limitation**: Serialization or execution issue → blocks all catalogs
+
+**Example of getting this wrong**: RM16 was retired as "DuckLake will never support
+PK/UNIQUE" but the test used `hog:memory`, where PK/UNIQUE works server-side. The
+real blocker was L2 (constraint metadata not synced to local binder).
+
 ## Common False Positives
 
 These patterns frequently look like bugs but aren't:

--- a/skills/bug-verification/references/provenance-tree.md
+++ b/skills/bug-verification/references/provenance-tree.md
@@ -91,3 +91,4 @@ DuckHog issues or test errors:
 | "DuckLake loses rows on large INSERT" | DuckHog chunk boundary bug in `posthog_insert.cpp`. psql inserts all rows correctly. |
 | "BOOLEAN renders as 0/1 through DuckLake" | Test used `query II` (integer format specifier) instead of `query TI`. BOOLEAN works correctly through Arrow Flight. |
 | "INSERT RETURNING broken on DuckLake" | DuckHog code at `posthog_catalog.cpp:309` throws NotImplementedException for partial column RETURNING. Not upstream. |
+| "RM16 retired because DuckLake lacks PK/UNIQUE" | Test used `hog:memory` (which supports PK server-side), not DuckLake. Real blocker was L2 (constraint metadata not synced to local binder). |

--- a/test/sql_roadmap.md
+++ b/test/sql_roadmap.md
@@ -70,10 +70,10 @@ Graduated targets (now part of normal integration suite):
 - [`table_functions_remote.test_slow`](sql/integration/table_functions_remote.test_slow) (RM11, RM12, RM13) — [#34](https://github.com/PostHog/duckhog/issues/34), [#35](https://github.com/PostHog/duckhog/issues/35), [#36](https://github.com/PostHog/duckhog/issues/36)
 - [`insert_default_values_remote.test_slow`](sql/integration/insert_default_values_remote.test_slow) (RM18)
 
-Retired targets (will never be supported on DuckLake):
+Retired targets:
 - RM15 (INSERT RETURNING) — DuckLake does not support RETURNING on any DML verb; chunk-echo was semantically wrong (echoed client input, not server state). Test file kept as `statement error` coverage.
-- RM16 (ON CONFLICT DO NOTHING) — [#38](https://github.com/PostHog/duckhog/issues/38) — DuckLake will never support PK/UNIQUE constraints ([ducklake#66](https://github.com/duckdb/ducklake/issues/66), [ducklake#290](https://github.com/duckdb/ducklake/issues/290))
-- RM17 (ON CONFLICT DO UPDATE) — [#39](https://github.com/PostHog/duckhog/issues/39) — same as RM16
+- RM16 (ON CONFLICT DO NOTHING) — [#38](https://github.com/PostHog/duckhog/issues/38) — duplicate of RM23; both tested `hog:memory` with ON CONFLICT DO NOTHING. Blocked by L2 (constraint metadata not synced to local binder). On DuckLake catalogs, additionally blocked because DuckLake will never support PK/UNIQUE constraints ([ducklake#66](https://github.com/duckdb/ducklake/issues/66), [ducklake#290](https://github.com/duckdb/ducklake/issues/290))
+- RM17 (ON CONFLICT DO UPDATE) — [#39](https://github.com/PostHog/duckhog/issues/39) — same blockers as RM16; RM23 covers the rewrite path for all ON CONFLICT variants
 - RM19 (ON CONFLICT DO NOTHING RETURNING) — [#40](https://github.com/PostHog/duckhog/issues/40) — same as RM16; also blocked by DuckLake lacking RETURNING support
 - RM20 (DEFAULT VALUES + RETURNING) — [#41](https://github.com/PostHog/duckhog/issues/41) — subsumes L1 limitation; RETURNING itself is not supported
 - RM21 (Partial columns + RETURNING) — [#42](https://github.com/PostHog/duckhog/issues/42) — same as RM20


### PR DESCRIPTION
## Summary

- Remove roadmap test files for RM16, RM17, RM19 (ON CONFLICT DO NOTHING, DO UPDATE, DO NOTHING RETURNING)
- Move them to "Retired targets" in `test/sql_roadmap.md` — DuckLake will never support PK/UNIQUE constraints ([ducklake#66](https://github.com/duckdb/ducklake/issues/66), [ducklake#290](https://github.com/duckdb/ducklake/issues/290))
- Update `docs/RELATED_BUGS.md` accordingly

DuckLake's upsert alternative is MERGE INTO, which DuckHog already supports (RM09).

## Files

| File | Change |
|------|--------|
| `test/sql/roadmap/rm16_on_conflict_do_nothing_remote.test_slow` | Removed |
| `test/sql/roadmap/rm17_on_conflict_do_update_remote.test_slow` | Removed |
| `test/sql/roadmap/rm19_on_conflict_do_nothing_returning_remote.test_slow` | Removed |
| `test/sql_roadmap.md` | Retire RM16/RM17/RM19, add rationale |
| `docs/RELATED_BUGS.md` | Update related entries |

## Test plan

- [x] No code changes — roadmap test removal only
- [x] `just test-all` unaffected (roadmap tests excluded from normal suite)