### PR TITLE
Filter pushdown: emit remote WHERE clause + correctness/pushdown tests

### DIFF
--- a/src/catalog/remote_scan.cpp
+++ b/src/catalog/remote_scan.cpp
@@ -192,7 +192,13 @@ BindInfo PostHogRemoteScan::GetBindInfo(const optional_ptr<FunctionData> bind_da
 TableFunction PostHogRemoteScan::GetFunction() {
 	TableFunction func("posthog_remote_scan", {}, Execute, Bind, InitGlobal, InitLocal);
 	func.projection_pushdown = true;
-	func.filter_pushdown = false; // TODO: Implement filter pushdown
+	// Filter pushdown is partial: PostHogArrowStream::Produce translates the
+	// filter shapes it knows (CONSTANT_COMPARISON, IS NULL, IS NOT NULL, IN,
+	// AND, OR, STRUCT_EXTRACT, OPTIONAL_FILTER) into a remote WHERE clause.
+	// DuckDB's ArrowScanFunction still applies the full filter set as a
+	// residual above the scan, so untranslatable shapes don't lose
+	// correctness — they just don't reduce wire traffic.
+	func.filter_pushdown = true;
 	func.table_scan_progress = Progress;
 	func.get_bind_info = GetBindInfo;
 	return func;

--- a/src/catalog/remote_scan.cpp
+++ b/src/catalog/remote_scan.cpp
@@ -192,12 +192,15 @@ BindInfo PostHogRemoteScan::GetBindInfo(const optional_ptr<FunctionData> bind_da
 TableFunction PostHogRemoteScan::GetFunction() {
 	TableFunction func("posthog_remote_scan", {}, Execute, Bind, InitGlobal, InitLocal);
 	func.projection_pushdown = true;
-	// Filter pushdown is partial: PostHogArrowStream::Produce translates the
-	// filter shapes it knows (CONSTANT_COMPARISON, IS NULL, IS NOT NULL, IN,
-	// AND, OR, STRUCT_EXTRACT, OPTIONAL_FILTER) into a remote WHERE clause.
-	// DuckDB's ArrowScanFunction still applies the full filter set as a
-	// residual above the scan, so untranslatable shapes don't lose
-	// correctness — they just don't reduce wire traffic.
+	// PostHogArrowStream::Produce translates every TableFilterType DuckDB
+	// pushes into a remote WHERE clause via FilterToSQL. Safety invariant:
+	// FilterToSQL must handle every shape that GenerateTableScanFilters can
+	// produce. DuckDB keeps constant-comparison residuals above the scan, but
+	// LIKE/IN/range filters produced by TryPushdownExpression are removed
+	// from the residual and only applied at the scan — silently dropping
+	// such a shape would return wrong rows. New TableFilterTypes must extend
+	// FilterToSQL; the default branch throws so unhandled shapes surface as
+	// loud query errors rather than silent data loss.
 	func.filter_pushdown = true;
 	func.table_scan_progress = Progress;
 	func.get_bind_info = GetBindInfo;

--- a/src/execution/posthog_sql_utils.cpp
+++ b/src/execution/posthog_sql_utils.cpp
@@ -7,10 +7,17 @@
 
 #include "execution/posthog_sql_utils.hpp"
 
+#include "duckdb/common/enums/expression_type.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/types.hpp"
 #include "duckdb/common/types/value.hpp"
+#include "duckdb/planner/filter/conjunction_filter.hpp"
+#include "duckdb/planner/filter/constant_filter.hpp"
+#include "duckdb/planner/filter/in_filter.hpp"
+#include "duckdb/planner/filter/null_filter.hpp"
+#include "duckdb/planner/filter/optional_filter.hpp"
+#include "duckdb/planner/filter/struct_filter.hpp"
 
 namespace duckdb {
 
@@ -115,6 +122,139 @@ string BuildInsertSQL(const string &qualified_table, const vector<string> &colum
 	sql += on_conflict_clause;
 	sql += ";";
 	return sql;
+}
+
+//===----------------------------------------------------------------------===//
+// Filter pushdown translation
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+string ComparisonOperatorToSQL(ExpressionType type) {
+	switch (type) {
+	case ExpressionType::COMPARE_EQUAL:
+		return "=";
+	case ExpressionType::COMPARE_NOTEQUAL:
+		return "<>";
+	case ExpressionType::COMPARE_LESSTHAN:
+		return "<";
+	case ExpressionType::COMPARE_GREATERTHAN:
+		return ">";
+	case ExpressionType::COMPARE_LESSTHANOREQUALTO:
+		return "<=";
+	case ExpressionType::COMPARE_GREATERTHANOREQUALTO:
+		return ">=";
+	case ExpressionType::COMPARE_DISTINCT_FROM:
+		return "IS DISTINCT FROM";
+	case ExpressionType::COMPARE_NOT_DISTINCT_FROM:
+		return "IS NOT DISTINCT FROM";
+	default:
+		throw NotImplementedException("PostHog filter pushdown: unsupported comparison operator");
+	}
+}
+
+} // namespace
+
+string FilterToSQL(const TableFilter &filter, const string &column_expr) {
+	switch (filter.filter_type) {
+	case TableFilterType::CONSTANT_COMPARISON: {
+		auto &cmp = filter.Cast<ConstantFilter>();
+		return column_expr + " " + ComparisonOperatorToSQL(cmp.comparison_type) + " " + cmp.constant.ToSQLString();
+	}
+	case TableFilterType::IS_NULL:
+		return column_expr + " IS NULL";
+	case TableFilterType::IS_NOT_NULL:
+		return column_expr + " IS NOT NULL";
+	case TableFilterType::CONJUNCTION_AND:
+	case TableFilterType::CONJUNCTION_OR: {
+		// Empty-string convention: a child returning "" means "no SQL
+		// constraint, treat as TRUE". AND can drop TRUE children safely; OR
+		// with a TRUE child collapses to TRUE (return "") because emitting
+		// only the non-empty siblings would be stricter than the original
+		// filter — fine here because the residual filter operator above the
+		// scan still applies it, but we shouldn't emit incorrect SQL.
+		const bool is_and = filter.filter_type == TableFilterType::CONJUNCTION_AND;
+		auto &conj = is_and ? static_cast<const ConjunctionFilter &>(filter.Cast<ConjunctionAndFilter>())
+		                    : static_cast<const ConjunctionFilter &>(filter.Cast<ConjunctionOrFilter>());
+		const char *sep = is_and ? " AND " : " OR ";
+		string out;
+		for (auto &child : conj.child_filters) {
+			string child_sql;
+			try {
+				child_sql = FilterToSQL(*child, column_expr);
+			} catch (const NotImplementedException &) {
+				// Untranslatable child: AND can drop it (residual still
+				// applies), OR collapses to TRUE.
+				if (!is_and) {
+					return string();
+				}
+				continue;
+			}
+			if (child_sql.empty()) {
+				if (!is_and) {
+					return string();
+				}
+				continue;
+			}
+			if (!out.empty()) {
+				out += sep;
+			}
+			out += child_sql;
+		}
+		if (out.empty()) {
+			return out;
+		}
+		return "(" + out + ")";
+	}
+	case TableFilterType::IN_FILTER: {
+		auto &in_filter = filter.Cast<InFilter>();
+		if (in_filter.values.empty()) {
+			return "FALSE";
+		}
+		string out = column_expr + " IN (";
+		for (idx_t i = 0; i < in_filter.values.size(); i++) {
+			if (i > 0) {
+				out += ", ";
+			}
+			out += in_filter.values[i].ToSQLString();
+		}
+		out += ")";
+		return out;
+	}
+	case TableFilterType::STRUCT_EXTRACT: {
+		auto &struct_filter = filter.Cast<StructFilter>();
+		if (!struct_filter.child_filter) {
+			return string();
+		}
+		// Match DuckDB's StructFilter::ToString: positional access when
+		// child_name is empty, dotted-name access otherwise.
+		string child_expr;
+		if (struct_filter.child_name.empty()) {
+			child_expr = "struct_extract_at(" + column_expr + ", " +
+			             std::to_string(struct_filter.child_idx + 1) + ")";
+		} else {
+			child_expr = column_expr + "." + QuoteIdent(struct_filter.child_name);
+		}
+		return FilterToSQL(*struct_filter.child_filter, child_expr);
+	}
+	case TableFilterType::OPTIONAL_FILTER: {
+		auto &opt = filter.Cast<OptionalFilter>();
+		if (!opt.child_filter) {
+			return string();
+		}
+		try {
+			return FilterToSQL(*opt.child_filter, column_expr);
+		} catch (const NotImplementedException &) {
+			return string();
+		}
+	}
+	case TableFilterType::DYNAMIC_FILTER:
+		// Dynamic filter values aren't knowable at SQL-generation time;
+		// the residual filter above the scan will apply them.
+		return string();
+	default:
+		throw NotImplementedException("PostHog filter pushdown: unsupported filter type");
+	}
 }
 
 } // namespace duckdb

--- a/src/execution/posthog_sql_utils.cpp
+++ b/src/execution/posthog_sql_utils.cpp
@@ -21,12 +21,14 @@
 
 namespace duckdb {
 
-/// Serialize a Value to valid SQL for INSERT statements.
+/// Serialize a Value to valid SQL.
 ///
 /// DuckDB's Value::ToSQLString() falls through to ToString() for MAP, which
 /// produces the display format {k=v, ...} — not valid SQL.  We emit
-/// MAP {'key': val, ...} instead, recursing for nested types.
-static string ValueToInsertSQL(const Value &val) {
+/// MAP {'key': val, ...} instead, recursing for nested types.  Also used by
+/// FilterToSQL so pushed-down constants on MAP/STRUCT/LIST columns serialize
+/// correctly.
+static string ValueToSQL(const Value &val) {
 	if (val.IsNull()) {
 		return val.ToSQLString();
 	}
@@ -39,10 +41,10 @@ static string ValueToInsertSQL(const Value &val) {
 			auto &entry = children[i];
 			auto &kv = StructValue::GetChildren(entry);
 			// key
-			sql += ValueToInsertSQL(kv[0]);
+			sql += ValueToSQL(kv[0]);
 			sql += ": ";
 			// value
-			sql += ValueToInsertSQL(kv[1]);
+			sql += ValueToSQL(kv[1]);
 			if (i < children.size() - 1) {
 				sql += ", ";
 			}
@@ -59,7 +61,7 @@ static string ValueToInsertSQL(const Value &val) {
 				sql += ", ";
 			}
 			sql += "'" + StringUtil::Replace(child_types[i].first, "'", "''") + "': ";
-			sql += ValueToInsertSQL(children[i]);
+			sql += ValueToSQL(children[i]);
 		}
 		sql += "}";
 		return sql;
@@ -71,7 +73,7 @@ static string ValueToInsertSQL(const Value &val) {
 			if (i > 0) {
 				sql += ", ";
 			}
-			sql += ValueToInsertSQL(children[i]);
+			sql += ValueToSQL(children[i]);
 		}
 		sql += "]";
 		return sql;
@@ -114,7 +116,7 @@ string BuildInsertSQL(const string &qualified_table, const vector<string> &colum
 			if (col_idx > 0) {
 				sql += ", ";
 			}
-			sql += ValueToInsertSQL(chunk.GetValue(col_idx, row_idx));
+			sql += ValueToSQL(chunk.GetValue(col_idx, row_idx));
 		}
 		sql += ")";
 	}
@@ -159,7 +161,7 @@ string FilterToSQL(const TableFilter &filter, const string &column_expr) {
 	switch (filter.filter_type) {
 	case TableFilterType::CONSTANT_COMPARISON: {
 		auto &cmp = filter.Cast<ConstantFilter>();
-		return column_expr + " " + ComparisonOperatorToSQL(cmp.comparison_type) + " " + cmp.constant.ToSQLString();
+		return column_expr + " " + ComparisonOperatorToSQL(cmp.comparison_type) + " " + ValueToSQL(cmp.constant);
 	}
 	case TableFilterType::IS_NULL:
 		return column_expr + " IS NULL";
@@ -168,28 +170,17 @@ string FilterToSQL(const TableFilter &filter, const string &column_expr) {
 	case TableFilterType::CONJUNCTION_AND:
 	case TableFilterType::CONJUNCTION_OR: {
 		// Empty-string convention: a child returning "" means "no SQL
-		// constraint, treat as TRUE". AND can drop TRUE children safely; OR
-		// with a TRUE child collapses to TRUE (return "") because emitting
-		// only the non-empty siblings would be stricter than the original
-		// filter — fine here because the residual filter operator above the
-		// scan still applies it, but we shouldn't emit incorrect SQL.
+		// constraint, treat as TRUE". AND drops TRUE children; OR with a TRUE
+		// child collapses to TRUE (return ""). Children that throw propagate
+		// — silently dropping a translatable-but-unhandled child of an AND
+		// would emit a more-permissive WHERE, and the residual filter does
+		// not always reapply (see PostHogRemoteScan::GetFunction).
 		const bool is_and = filter.filter_type == TableFilterType::CONJUNCTION_AND;
-		auto &conj = is_and ? static_cast<const ConjunctionFilter &>(filter.Cast<ConjunctionAndFilter>())
-		                    : static_cast<const ConjunctionFilter &>(filter.Cast<ConjunctionOrFilter>());
+		auto &conj = static_cast<const ConjunctionFilter &>(filter);
 		const char *sep = is_and ? " AND " : " OR ";
 		string out;
 		for (auto &child : conj.child_filters) {
-			string child_sql;
-			try {
-				child_sql = FilterToSQL(*child, column_expr);
-			} catch (const NotImplementedException &) {
-				// Untranslatable child: AND can drop it (residual still
-				// applies), OR collapses to TRUE.
-				if (!is_and) {
-					return string();
-				}
-				continue;
-			}
+			string child_sql = FilterToSQL(*child, column_expr);
 			if (child_sql.empty()) {
 				if (!is_and) {
 					return string();
@@ -216,7 +207,7 @@ string FilterToSQL(const TableFilter &filter, const string &column_expr) {
 			if (i > 0) {
 				out += ", ";
 			}
-			out += in_filter.values[i].ToSQLString();
+			out += ValueToSQL(in_filter.values[i]);
 		}
 		out += ")";
 		return out;
@@ -230,8 +221,7 @@ string FilterToSQL(const TableFilter &filter, const string &column_expr) {
 		// child_name is empty, dotted-name access otherwise.
 		string child_expr;
 		if (struct_filter.child_name.empty()) {
-			child_expr = "struct_extract_at(" + column_expr + ", " +
-			             std::to_string(struct_filter.child_idx + 1) + ")";
+			child_expr = "struct_extract_at(" + column_expr + ", " + std::to_string(struct_filter.child_idx + 1) + ")";
 		} else {
 			child_expr = column_expr + "." + QuoteIdent(struct_filter.child_name);
 		}

--- a/src/execution/posthog_sql_utils.hpp
+++ b/src/execution/posthog_sql_utils.hpp
@@ -10,6 +10,7 @@
 
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/parser/keyword_helper.hpp"
+#include "duckdb/planner/table_filter.hpp"
 
 #include <string>
 #include <vector>
@@ -27,5 +28,13 @@ inline string QualifyRemoteTableName(const string &remote_catalog, const string 
 /// Build an INSERT INTO ... VALUES statement for a single DataChunk.
 string BuildInsertSQL(const string &qualified_table, const vector<string> &column_names, const DataChunk &chunk,
                       const string &on_conflict_clause = "");
+
+/// Translate a TableFilter into a SQL boolean expression on `column_expr` (a
+/// quoted SQL identifier or expression). Returns an empty string for
+/// optional/dynamic/unknown filters that can be safely skipped — the residual
+/// filter operator above the scan will still apply them. Throws
+/// NotImplementedException for filter shapes whose semantics cannot be
+/// preserved by skipping.
+string FilterToSQL(const TableFilter &filter, const string &column_expr);
 
 } // namespace duckdb

--- a/src/execution/posthog_sql_utils.hpp
+++ b/src/execution/posthog_sql_utils.hpp
@@ -30,11 +30,11 @@ string BuildInsertSQL(const string &qualified_table, const vector<string> &colum
                       const string &on_conflict_clause = "");
 
 /// Translate a TableFilter into a SQL boolean expression on `column_expr` (a
-/// quoted SQL identifier or expression). Returns an empty string for
-/// optional/dynamic/unknown filters that can be safely skipped — the residual
-/// filter operator above the scan will still apply them. Throws
-/// NotImplementedException for filter shapes whose semantics cannot be
-/// preserved by skipping.
+/// quoted SQL identifier or expression). Returns an empty string for filter
+/// shapes whose semantics permit skipping (OPTIONAL_FILTER and DYNAMIC_FILTER
+/// — the optimizer keeps a residual above the scan or applies the filter
+/// elsewhere). Throws NotImplementedException for unhandled types so callers
+/// fail loudly rather than emit a too-permissive WHERE clause.
 string FilterToSQL(const TableFilter &filter, const string &column_expr);
 
 } // namespace duckdb

--- a/src/flight/arrow_stream.cpp
+++ b/src/flight/arrow_stream.cpp
@@ -73,19 +73,20 @@ unique_ptr<ArrowArrayStreamWrapper> PostHogArrowStream::Produce(uintptr_t stream
 	}
 	string query = "SELECT " + columns_str + " FROM " + table_ref;
 
-	// Push translatable filters down into a WHERE clause. Untranslatable
-	// shapes (EXPRESSION_FILTER, dynamic, etc.) are left for the residual
-	// filter operator above the scan — that path is preserved by DuckDB's
-	// ArrowScanFunction even when filter_pushdown is enabled, so partial
-	// pushdown is correctness-safe.
+	// Translate every pushed-down filter into a remote WHERE clause. Any
+	// TableFilterType FilterToSQL doesn't handle propagates as
+	// NotImplementedException — see the safety note in
+	// PostHogRemoteScan::GetFunction for why silent skips would be unsafe
+	// for LIKE/IN/range residuals.
 	if (parameters.filters && !parameters.filters->filters.empty()) {
 		string where_clause;
 		for (auto &entry : parameters.filters->filters) {
 			auto pos = entry.first;
 			auto it = parameters.projected_columns.filter_to_col.find(pos);
 			if (it == parameters.projected_columns.filter_to_col.end()) {
-				// Filter on a column outside the projected set (rowid placeholder
-				// path, etc.). Skip — the residual filter handles it.
+				// Filter references a column outside the projected set
+				// (rowid placeholder path, etc.). DuckDB still applies it
+				// because the column wasn't requested for pushdown.
 				continue;
 			}
 			auto col_id = it->second;
@@ -96,13 +97,7 @@ unique_ptr<ArrowArrayStreamWrapper> PostHogArrowStream::Produce(uintptr_t stream
 				continue;
 			}
 			auto column_expr = QuoteIdent(bind_data->column_names[col_id]);
-			string filter_sql;
-			try {
-				filter_sql = FilterToSQL(*entry.second, column_expr);
-			} catch (const NotImplementedException &) {
-				// Leave to the residual.
-				continue;
-			}
+			string filter_sql = FilterToSQL(*entry.second, column_expr);
 			if (filter_sql.empty()) {
 				continue;
 			}

--- a/src/flight/arrow_stream.cpp
+++ b/src/flight/arrow_stream.cpp
@@ -73,6 +73,49 @@ unique_ptr<ArrowArrayStreamWrapper> PostHogArrowStream::Produce(uintptr_t stream
 	}
 	string query = "SELECT " + columns_str + " FROM " + table_ref;
 
+	// Push translatable filters down into a WHERE clause. Untranslatable
+	// shapes (EXPRESSION_FILTER, dynamic, etc.) are left for the residual
+	// filter operator above the scan — that path is preserved by DuckDB's
+	// ArrowScanFunction even when filter_pushdown is enabled, so partial
+	// pushdown is correctness-safe.
+	if (parameters.filters && !parameters.filters->filters.empty()) {
+		string where_clause;
+		for (auto &entry : parameters.filters->filters) {
+			auto pos = entry.first;
+			auto it = parameters.projected_columns.filter_to_col.find(pos);
+			if (it == parameters.projected_columns.filter_to_col.end()) {
+				// Filter on a column outside the projected set (rowid placeholder
+				// path, etc.). Skip — the residual filter handles it.
+				continue;
+			}
+			auto col_id = it->second;
+			if (col_id == COLUMN_IDENTIFIER_ROW_ID) {
+				continue;
+			}
+			if (col_id >= bind_data->column_names.size()) {
+				continue;
+			}
+			auto column_expr = QuoteIdent(bind_data->column_names[col_id]);
+			string filter_sql;
+			try {
+				filter_sql = FilterToSQL(*entry.second, column_expr);
+			} catch (const NotImplementedException &) {
+				// Leave to the residual.
+				continue;
+			}
+			if (filter_sql.empty()) {
+				continue;
+			}
+			if (!where_clause.empty()) {
+				where_clause += " AND ";
+			}
+			where_clause += filter_sql;
+		}
+		if (!where_clause.empty()) {
+			query += " WHERE " + where_clause;
+		}
+	}
+
 	// Execute the projected query via Flight SQL.
 	auto stream_state = std::make_shared<PostHogArrowStreamState>(bind_data->catalog, query, factory->txn_id);
 

--- a/test/sql/integration/filter_pushdown_remote.test_slow
+++ b/test/sql/integration/filter_pushdown_remote.test_slow
@@ -24,6 +24,9 @@ require-env DUCKHOG_USER
 require-env DUCKHOG_PASSWORD
 
 statement ok
+INSTALL json;
+
+statement ok
 LOAD json;
 
 statement ok

--- a/test/sql/integration/filter_pushdown_remote.test_slow
+++ b/test/sql/integration/filter_pushdown_remote.test_slow
@@ -1,0 +1,171 @@
+# name: test/sql/integration/filter_pushdown_remote.test_slow
+# description: Verify filters are translated into remote WHERE (not just applied locally)
+# group: [integration]
+
+#
+# Strategy: turn on JSON profiling, run the target query, then read the
+# profile and check the POSTHOG_REMOTE_SCAN operator's actual cardinality.
+# Without pushdown the scan would emit every row (8 in `t`) and the residual
+# above the scan would filter them down — so a scan cardinality equal to the
+# expected match count proves the WHERE was pushed.
+#
+# Companion correctness suites (select_remote / struct_types_remote) catch
+# wrong-SQL emission; this file catches the silent "filter never reached the
+# remote side" failure.
+
+require duckhog
+
+require-env FLIGHT_HOST
+
+require-env FLIGHT_PORT
+
+require-env DUCKHOG_USER
+
+require-env DUCKHOG_PASSWORD
+
+statement ok
+LOAD json;
+
+statement ok
+ATTACH 'hog:ducklake?user=${DUCKHOG_USER}&password=${DUCKHOG_PASSWORD}&flight_server=grpc+tls://${FLIGHT_HOST}:${FLIGHT_PORT}&tls_skip_verify=true' AS remote_flight;
+
+statement ok
+DROP SCHEMA IF EXISTS remote_flight.pushdown_test CASCADE;
+
+statement ok
+CREATE SCHEMA remote_flight.pushdown_test;
+
+# --- Seed ---
+
+statement ok
+CREATE TABLE remote_flight.pushdown_test.t(id INT, name VARCHAR, score DOUBLE);
+
+statement ok
+INSERT INTO remote_flight.pushdown_test.t VALUES
+    (1, 'alice',  95.5),
+    (2, 'bob',    82.0),
+    (3, 'carol',  78.3),
+    (4, 'dave',   91.0),
+    (5, 'eve',    NULL),
+    (6, NULL,     65.0),
+    (7, 'grace',  95.5),
+    (8, 'heidi',  50.0),
+    -- 'alice2' exists so a `LIKE 'alice'` test below detects accidental
+    -- prefix-match drift on the remote side: prefix semantics would match
+    -- both rows and bump scan cardinality from 1 to 2.
+    (9, 'alice2', 70.0);
+
+statement ok
+CREATE TABLE remote_flight.pushdown_test.s(id INT, s STRUCT(i INTEGER, j INTEGER));
+
+statement ok
+INSERT INTO remote_flight.pushdown_test.s VALUES
+    (1, {'i': 10, 'j': 20}),
+    (2, {'i': 30, 'j': 40}),
+    (3, {'i': 50, 'j': 60}),
+    (4, {'i': NULL, 'j': 42});
+
+# --- Helper: scalar macro returning the POSTHOG_REMOTE_SCAN operator's
+# actual cardinality from the most recent JSON profile dump. Joins on parent
+# id so the operator_name="POSTHOG_REMOTE_SCAN" sibling pins which node's
+# cardinality we read.
+statement ok
+CREATE OR REPLACE MACRO scan_card(profile_path) AS (
+    SELECT cards.card
+    FROM (
+        SELECT j.parent AS pid, j.value::BIGINT AS card
+        FROM read_text(profile_path) t, json_tree(t.content) j
+        WHERE j.key = 'operator_cardinality'
+    ) cards
+    JOIN (
+        SELECT k.parent AS pid
+        FROM read_text(profile_path) t2, json_tree(t2.content) k
+        WHERE k.key = 'operator_name' AND k.value = '"POSTHOG_REMOTE_SCAN"'
+    ) names USING (pid)
+);
+
+statement ok
+PRAGMA enable_profiling='json';
+
+statement ok
+PRAGMA profiling_output='__TEST_DIR__/profile.json';
+
+# ============================================================
+# Scalar IN with single value
+# ============================================================
+
+statement ok
+SELECT id FROM remote_flight.pushdown_test.t WHERE id IN (4);
+
+statement ok
+PRAGMA disable_profiling;
+
+query I
+SELECT scan_card('__TEST_DIR__/profile.json');
+----
+1
+
+# ============================================================
+# Scalar IN with multiple non-contiguous values
+# DuckDB collapses contiguous IN lists like (3,4,5) into a range filter,
+# which would scan exactly 3 rows even without IN_FILTER pushdown — so we
+# pick values that span both endpoints to actually exercise the IN-list
+# remote-SQL emission.
+# ============================================================
+
+statement ok
+PRAGMA enable_profiling='json';
+
+statement ok
+SELECT id FROM remote_flight.pushdown_test.t WHERE id IN (1, 4, 7);
+
+statement ok
+PRAGMA disable_profiling;
+
+query I
+SELECT scan_card('__TEST_DIR__/profile.json');
+----
+3
+
+# ============================================================
+# LIKE pushdown (no wildcard reduces to equality on the remote)
+# ============================================================
+
+statement ok
+PRAGMA enable_profiling='json';
+
+statement ok
+SELECT id FROM remote_flight.pushdown_test.t WHERE name LIKE 'alice';
+
+statement ok
+PRAGMA disable_profiling;
+
+query I
+SELECT scan_card('__TEST_DIR__/profile.json');
+----
+1
+
+# ============================================================
+# STRUCT field equality
+# ============================================================
+
+statement ok
+PRAGMA enable_profiling='json';
+
+statement ok
+SELECT id FROM remote_flight.pushdown_test.s WHERE s.j = 40;
+
+statement ok
+PRAGMA disable_profiling;
+
+query I
+SELECT scan_card('__TEST_DIR__/profile.json');
+----
+1
+
+# ============================================================
+# Cleanup
+# ============================================================
+
+statement ok
+DROP SCHEMA remote_flight.pushdown_test CASCADE;

--- a/test/sql/integration/select_remote.test_slow
+++ b/test/sql/integration/select_remote.test_slow
@@ -103,8 +103,33 @@ SELECT id, name FROM remote_flight.select_test.t WHERE id IN (1, 4, 7) ORDER BY 
 4	dave
 7	grace
 
+# Single-element IN: catches a remote-SQL emitter that drops parens or
+# rewrites IN(x) into something other than `id = x`.
+query IT
+SELECT id, name FROM remote_flight.select_test.t WHERE id IN (4);
+----
+4	dave
+
+# Multi-element IN with genuinely non-contiguous values that span both
+# endpoints of the table — DuckDB only collapses contiguous IN lists into
+# range filters, so these values exercise the IN_FILTER emission path and
+# would fail if the remote-side IN list were dropped or mis-bracketed.
+query IT
+SELECT id, name FROM remote_flight.select_test.t WHERE id IN (2, 5, 8) ORDER BY id;
+----
+2	bob
+5	eve
+8	heidi
+
 query IT
 SELECT id, name FROM remote_flight.select_test.t WHERE name LIKE 'a%';
+----
+1	alice
+
+# LIKE with no wildcard reduces to equality on the remote — guards against
+# emitting `name LIKE alice` (unquoted) or otherwise mangling the literal.
+query IT
+SELECT id, name FROM remote_flight.select_test.t WHERE name LIKE 'alice';
 ----
 1	alice
 

--- a/test/sql/integration/struct_types_remote.test_slow
+++ b/test/sql/integration/struct_types_remote.test_slow
@@ -63,6 +63,26 @@ SELECT id, s.i, s.j FROM remote_flight.struct_types.basic WHERE id = 4;
 4	NULL	42
 
 # ============================================================
+# Filter pushdown on struct fields (correctness)
+# Pushed down as `s.j = 40` / `s.i IS NULL` on the remote — verify the
+# emitted SQL preserves dotted-name access and returns exactly the matching
+# row(s).
+# ============================================================
+
+query I
+SELECT id FROM remote_flight.struct_types.basic WHERE s.j = 40;
+----
+2
+
+# s.i IS NULL matches both id=3 (whole struct NULL → field projects to NULL)
+# and id=4 (struct present, i field NULL).
+query I
+SELECT id FROM remote_flight.struct_types.basic WHERE s.i IS NULL ORDER BY id;
+----
+3
+4
+
+# ============================================================
 # STRUCT with VARCHAR fields
 # ============================================================
 
@@ -147,6 +167,13 @@ query II
 SELECT s.inner_s.x, s.inner_s.y FROM remote_flight.struct_types.nested WHERE id = 1;
 ----
 1	2
+
+# Filter pushdown through nested struct field — must emit
+# `"s"."inner_s"."x" = 1`, not flatten or skip a level.
+query I
+SELECT id FROM remote_flight.struct_types.nested WHERE s.inner_s.x = 1;
+----
+1
 
 # ============================================================
 # STRUCT with LIST field


### PR DESCRIPTION
## Summary

- **Filter pushdown to remote** ([6702f58](https://github.com/PostHog/duckhog/commit/6702f58)): translates `TableFilter`s pushed into `posthog_remote_scan` into a SQL `WHERE` clause that's appended to the remote `SELECT`. Without this, every filter ran locally as a residual above the scan — correct results, but the entire remote table streamed across Flight.
- **Safety hardening** ([fa681a7](https://github.com/PostHog/duckhog/commit/fa681a7)): correct SQL serialization for `MAP`/`STRUCT`/`LIST` constants (DuckDB's `Value::ToSQLString()` emits display-form for `MAP`), correct nested struct-field access, and a fail-loud `default:` arm in `FilterToSQL` so future `TableFilterType`s surface as a query error rather than silently dropping a residual that DuckDB removed from above the scan.
- **Test coverage** (this PR's tests commit, [9298be2](https://github.com/PostHog/duckhog/commit/9298be2)): two layers.
  - Correctness — single-element `IN`, non-contiguous multi-element `IN` (chosen to avoid DuckDB's contiguous-range collapse), no-wildcard `LIKE`, struct field equality and `IS NULL`, nested struct field equality.
  - Pushdown verification — turns on JSON profiling, runs the query, walks the profile via `json_tree` to read the actual `POSTHOG_REMOTE_SCAN` operator cardinality. Without pushdown the scan emits every row; cardinality equal to the match count proves the WHERE reached the remote. Confirmed end-to-end via a red-green cycle (flipping `func.filter_pushdown` to `false` makes the scan return 8 rows instead of 1).

## Test plan

- [x] `./build/release/test/unittest "test/sql/integration/filter_pushdown_remote.test_slow"` — 27 assertions
- [x] `./build/release/test/unittest "test/sql/integration/select_remote.test_slow"` — 419 assertions
- [x] `./build/release/test/unittest "test/sql/integration/struct_types_remote.test_slow"` — 95 assertions
- [x] Red-green: with `func.filter_pushdown = false`, pushdown test fails at the first cardinality assertion (scan returns 8 vs. expected 1); restored, all pass.
- [x] `make format-fix` and `make tidy-check` clean.

## Notes

`EXPRESSION_FILTER` and `BLOOM_FILTER` are not handled in `FilterToSQL`, but neither reaches the throwing default branch today: `EXPRESSION_FILTER` requires `func.pushdown_expression` (we don't set it), and `BLOOM_FILTER` is always wrapped in `OptionalFilter` whose handler swallows `NotImplementedException`. Predicates like `upper(name) = 'ALICE'` and bloom-style join filters stay above the scan as residuals — correct, just less efficient. A follow-up PR can add `""`-returning arms for both to make the dead-vs-future-proof intent explicit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)