### PR TITLE
chore: pin github actions to commit shas

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -88,7 +88,7 @@ jobs:
       VCPKG_BINARY_SOURCES: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'clear;x-aws,s3://duckhog-vcpkg-cache/duckhog/,readwrite;http,https://vcpkg-cache.duckdb.org,read' || github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && 'clear;x-aws,s3://duckhog-vcpkg-cache/duckhog/,read;http,https://vcpkg-cache.duckdb.org,read' || 'clear;http,https://vcpkg-cache.duckdb.org,read' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
           submodules: recursive
@@ -164,12 +164,12 @@ jobs:
       VCPKG_BINARY_SOURCES: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'clear;x-aws,s3://duckhog-vcpkg-cache/duckhog/,readwrite;http,https://vcpkg-cache.duckdb.org,read' || github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && 'clear;x-aws,s3://duckhog-vcpkg-cache/duckhog/,read;http,https://vcpkg-cache.duckdb.org,read' || 'clear;http,https://vcpkg-cache.duckdb.org,read' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           submodules: recursive
 
       - name: Checkout duckgres
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           repository: PostHog/duckgres
           path: duckgres
@@ -188,7 +188,7 @@ jobs:
           mkdir -p ccache_dir
 
       - name: Restore ccache from stable build
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ./ccache_dir
           key: ccache-integration-unittest-${{ github.run_id }}-${{ github.run_attempt }}
@@ -222,7 +222,7 @@ jobs:
           CCACHE_DIR="${GITHUB_WORKSPACE}/ccache_dir" make release_unittest
 
       - name: Download extension artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: duckhog-v1.5.2-extension-linux_amd64
           path: build/release/extension/duckhog/


### PR DESCRIPTION
Pins actions in .github/workflows to commit SHAs via pinact. Generated by multi-gitter.