### PR TITLE
chore(ci): switch to PostHog/extension-ci-tools fork (SHA-pinned)

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -20,7 +20,11 @@ jobs:
   duckdb-stable-build-main:
     name: Build extension binaries (main)
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@ec20f45aabeb9fcfcfa044dda249597f066d4826
+    # Use PostHog's fork of duckdb/extension-ci-tools that SHA-pins its internal
+    # action references; the org-wide "Require actions to be pinned to a SHA"
+    # policy applies transitively to called reusable workflows.
+    # Upstream PR: https://github.com/duckdb/extension-ci-tools/pull/379
+    uses: PostHog/extension-ci-tools/.github/workflows/_extension_distribution.yml@d3e0ee09e2e392941f2e390e6cbab108a095daa4 # chore/pin-internal-actions
     with:
       duckdb_version: v1.5.2
       ci_tools_version: v1.5-variegata
@@ -39,7 +43,11 @@ jobs:
   duckdb-stable-build-pr:
     name: Build extension binaries (PR)
     if: ${{ github.event_name == 'pull_request' }}
-    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@ec20f45aabeb9fcfcfa044dda249597f066d4826
+    # Use PostHog's fork of duckdb/extension-ci-tools that SHA-pins its internal
+    # action references; the org-wide "Require actions to be pinned to a SHA"
+    # policy applies transitively to called reusable workflows.
+    # Upstream PR: https://github.com/duckdb/extension-ci-tools/pull/379
+    uses: PostHog/extension-ci-tools/.github/workflows/_extension_distribution.yml@d3e0ee09e2e392941f2e390e6cbab108a095daa4 # chore/pin-internal-actions
     with:
       duckdb_version: v1.5.2
       ci_tools_version: v1.5-variegata
@@ -57,7 +65,11 @@ jobs:
 
   code-quality-check:
     name: Code Quality Check
-    uses: duckdb/extension-ci-tools/.github/workflows/_extension_code_quality.yml@ec20f45aabeb9fcfcfa044dda249597f066d4826
+    # Use PostHog's fork of duckdb/extension-ci-tools that SHA-pins its internal
+    # action references; the org-wide "Require actions to be pinned to a SHA"
+    # policy applies transitively to called reusable workflows.
+    # Upstream PR: https://github.com/duckdb/extension-ci-tools/pull/379
+    uses: PostHog/extension-ci-tools/.github/workflows/_extension_code_quality.yml@d3e0ee09e2e392941f2e390e6cbab108a095daa4 # chore/pin-internal-actions
     with:
       duckdb_version: v1.5.2
       ci_tools_version: v1.5-variegata

--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -24,7 +24,7 @@ jobs:
     # action references; the org-wide "Require actions to be pinned to a SHA"
     # policy applies transitively to called reusable workflows.
     # Upstream PR: https://github.com/duckdb/extension-ci-tools/pull/379
-    uses: PostHog/extension-ci-tools/.github/workflows/_extension_distribution.yml@d3e0ee09e2e392941f2e390e6cbab108a095daa4 # chore/pin-internal-actions
+    uses: PostHog/extension-ci-tools/.github/workflows/_extension_distribution.yml@508d9a6bdc30636633857eaa916f474b9857bc1f # v1.5-variegata + pins
     with:
       duckdb_version: v1.5.2
       ci_tools_version: v1.5-variegata
@@ -47,7 +47,7 @@ jobs:
     # action references; the org-wide "Require actions to be pinned to a SHA"
     # policy applies transitively to called reusable workflows.
     # Upstream PR: https://github.com/duckdb/extension-ci-tools/pull/379
-    uses: PostHog/extension-ci-tools/.github/workflows/_extension_distribution.yml@d3e0ee09e2e392941f2e390e6cbab108a095daa4 # chore/pin-internal-actions
+    uses: PostHog/extension-ci-tools/.github/workflows/_extension_distribution.yml@508d9a6bdc30636633857eaa916f474b9857bc1f # v1.5-variegata + pins
     with:
       duckdb_version: v1.5.2
       ci_tools_version: v1.5-variegata
@@ -69,7 +69,7 @@ jobs:
     # action references; the org-wide "Require actions to be pinned to a SHA"
     # policy applies transitively to called reusable workflows.
     # Upstream PR: https://github.com/duckdb/extension-ci-tools/pull/379
-    uses: PostHog/extension-ci-tools/.github/workflows/_extension_code_quality.yml@d3e0ee09e2e392941f2e390e6cbab108a095daa4 # chore/pin-internal-actions
+    uses: PostHog/extension-ci-tools/.github/workflows/_extension_code_quality.yml@508d9a6bdc30636633857eaa916f474b9857bc1f # v1.5-variegata + pins
     with:
       duckdb_version: v1.5.2
       ci_tools_version: v1.5-variegata

--- a/.github/workflows/duckdb-next-canary.yml
+++ b/.github/workflows/duckdb-next-canary.yml
@@ -18,7 +18,11 @@ concurrency:
 jobs:
   duckdb-next-build:
     name: Build extension binaries (DuckDB main)
-    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@1d3a50b3414534f6787e28c1c5efaafb4beb4e8f
+    # Use PostHog's fork of duckdb/extension-ci-tools that SHA-pins its internal
+    # action references; the org-wide "Require actions to be pinned to a SHA"
+    # policy applies transitively to called reusable workflows.
+    # Upstream PR: https://github.com/duckdb/extension-ci-tools/pull/379
+    uses: PostHog/extension-ci-tools/.github/workflows/_extension_distribution.yml@d3e0ee09e2e392941f2e390e6cbab108a095daa4 # chore/pin-internal-actions
     with:
       duckdb_version: main
       ci_tools_version: main


### PR DESCRIPTION
duckdb/extension-ci-tools' reusable workflows use tag refs internally, which violates the org-wide "Require actions to be pinned to a full-length commit SHA" policy when called transitively.

[PostHog/extension-ci-tools](https://github.com/PostHog/extension-ci-tools) is a fork that SHA-pins those internal refs.

Upstream PR: https://github.com/duckdb/extension-ci-tools/pull/379

**Note**: the duckdb-next-canary job previously pinned a newer upstream SHA than the main pipeline as an early-warning mechanism. This change collapses both to the same fork SHA; the canary's early-warning behavior will only return when the fork is periodically re-synced from upstream. This change isn't ideal but it's the only way to keep this repo's actions working. My hope is that upstream merges my PR and we can ditch our fork.